### PR TITLE
Fixes to relative position encoding, improve plots and visualizations

### DIFF
--- a/mvts_transformer/src/options.py
+++ b/mvts_transformer/src/options.py
@@ -116,6 +116,8 @@ class Options(object):
 
         self.parser.add_argument('--epochs', type=int, default=400,
                                  help='Number of training epochs')
+        self.parser.add_argument('--patience', type=int, default=200,
+                                 help='Early stopping patience (stop if val loss does not reach a new best after this many epochs)')
         self.parser.add_argument('--val_interval', type=int, default=2,
                                  help='Evaluate on validation set every this many epochs. Must be >= 1.')
         self.parser.add_argument(
@@ -155,6 +157,8 @@ class Options(object):
                                  help="""Only applicable for ClimaX. If set to a non-negative integer, restrict attention to tokens within this distance""")
         self.parser.add_argument('--reg_lambda', type=float, default=0,
                                  help="""Regularizing weight for loss from attention smoothing.""")
+        self.parser.add_argument('--lambda_posenc_smoothness', type=float, default=0,
+                                 help="""Regularizing weight for loss for POS ENC smoothing.""")
         self.parser.add_argument('--max_seq_len', type=int,
                                  help="""Maximum input sequence length. Determines size of transformer layers.
                                  If not provided, then the value defined inside the data class will be used.""")
@@ -176,7 +180,7 @@ class Options(object):
                                  help='Dropout applied to most transformer encoder layers')
         self.parser.add_argument('--pos_encoding', choices={'fixed', 'learnable', 'learnable_sin_init', 'none'}, default='fixed',
                                  help='Method for ABSOLUTE positional encoding')
-        self.parser.add_argument('--relative_pos_encoding', choices={'alibi', 'erpe', 'none'}, default='none',
+        self.parser.add_argument('--relative_pos_encoding', choices={'alibi', 'erpe', 'erpe_alibi_init', 'none'}, default='none',
                                  help='Method for RELATIVE positional encoding')
         self.parser.add_argument('--activation', choices={'relu', 'gelu'}, default='gelu',
                                  help='Activation to be used in transformer encoder')

--- a/mvts_transformer/src/run_rpe.sh
+++ b/mvts_transformer/src/run_rpe.sh
@@ -1,32 +1,25 @@
+# Call ./run_rpe.sh AppliancesEnergy
 
-for DATA in AppliancesEnergy BenzeneConcentration BeijingPM10Quality BeijingPM25Quality IEEEPPG LiveFuelMoistureContent
+DATA=${1}
+for POSENC in erpe_alibi_init
 do
-    for POSENC in none erpe alibi
+    for LAM in 0
     do
-        # Baseline
-        for SEED in 0 1 2
+        for SEED in 0
         do
-            # Usage: ./run.sh AppliancesEnergy, from mvts_transformer/src directory. Run "mkdir output" first.
-            python main.py --comment "ClimaX BASELINE on ${DATA}" \
-                --seed $SEED --name ClimaX_smooth_${DATA}_patch=1_${POSENC}_seed=${SEED} \
-                --records_file climax_smooth_${DATA}_hyperparameter_test.xls \
+            python main.py --comment "ClimaX ${DATA}" \
+                --seed $SEED --name ClimaX_smooth_${DATA}_ERPEALIBI_ATTNSMOOTH \
+                --records_file ${DATA}_debug.xls \
                 --data_dir /mnt/beegfs/bulk/mirror/jyf6/datasets/TSER/$DATA/ --data_class tsra \
-                --pattern TRAIN --val_ratio 0.2 --epochs 500 --lr 0.001 \
-                --num_layers 3 --num_heads 16 --d_model 128 --dim_feedforward 512 \
+                --pattern TRAIN --val_pattern TEST --epochs 1000 --lr 0.001 \
+                --num_layers 3 --num_heads 8 --d_model 128 --dim_feedforward 512 \
                 --optimizer RAdam  --pos_encoding learnable --relative_pos_encoding $POSENC --task regression \
-                --model climax_smooth --patch_length 1 --stride 1 --reg_lambda 0 --smooth_attention
-
-            python main.py --comment "ClimaX PATCH8/2 on ${DATA}" \
-                --seed $SEED --name ClimaX_smooth_${DATA}_patch=8_${POSENC}_seed=${SEED} \
-                --records_file climax_smooth_${DATA}_hyperparameter_test.xls \
-                --data_dir /mnt/beegfs/bulk/mirror/jyf6/datasets/TSER/$DATA/ --data_class tsra \
-                --pattern TRAIN --val_ratio 0.2 --epochs 500 --lr 0.001 \
-                --num_layers 3 --num_heads 16 --d_model 128 --dim_feedforward 512 \
-                --optimizer RAdam  --pos_encoding learnable --relative_pos_encoding $POSENC --task regression \
-                --model climax_smooth --patch_length 8 --stride 2 --reg_lambda 0 --smooth_attention
+                --model climax_smooth --patch_length 1 --stride 1 --reg_lambda $LAM --smooth_attention \
+                --lambda_posenc_smoothness 0 --plot_loss --plot_accuracy
         done
     done
 done
+
 
 # Note: --pattern TRAIN --val_ratio 0.2 validates on 20% of train set
 # Note: --pattern TRAIN --val_pattern TEST validates on test set

--- a/mvts_transformer/src/utils/utils.py
+++ b/mvts_transformer/src/utils/utils.py
@@ -284,7 +284,7 @@ def export_record(filepath, values):
 
 
 def register_record(
-    filepath, timestamp, experiment_name, best_metrics, final_metrics=None, comment=""
+    filepath, timestamp, experiment_name, best_metrics, final_metrics=None, test_metrics=None, comment=""
 ):
     """
     Adds the best and final metrics of a given experiment as a record in an excel sheet with other experiment records.
@@ -295,6 +295,7 @@ def register_record(
         experiment_name: string
         best_metrics: dict of metrics at best epoch {metric_name: metric_value}. Includes "epoch" as first key
         final_metrics: dict of metrics at final epoch {metric_name: metric_value}. Includes "epoch" as first key
+        test_metrics: dict of TEST metrics at final epoch {metric_name: metric_value}. Includes "epoch" as first key
         comment: optional description
     """
     metrics_names, metrics_values = zip(*best_metrics.items())
@@ -302,7 +303,9 @@ def register_record(
     if final_metrics is not None:
         final_metrics_names, final_metrics_values = zip(*final_metrics.items())
         row_values += list(final_metrics_values)
-
+    if test_metrics is not None:
+        test_metrics_names, test_metrics_values = zip(*test_metrics.items())
+        row_values += list(test_metrics_values)
     if not os.path.exists(filepath):  # Create a records file for the first time
         logger.warning(
             "Records file '{}' does not exist! Creating new file ...".format(filepath)
@@ -313,6 +316,8 @@ def register_record(
         header = ["Timestamp", "Name", "Comment"] + ["Best " + m for m in metrics_names]
         if final_metrics is not None:
             header += ["Final " + m for m in final_metrics_names]
+        if test_metrics is not None:
+            header += ["Test " + m for m in test_metrics_names]
         book = xlwt.Workbook()  # excel work book
         book = write_table_to_sheet([header, row_values], book, sheet_name="records")
         book.save(filepath)


### PR DESCRIPTION
1) Add support for "erpe_alibi_init", which uses a learnable bias for each relative offset, initialized to be ALIBI (linear scaling before softmax). In practice this means that some heads behave as local conv/smoothing, and some heads can aggregate info across the entire time series.

2) Improve some plots/visualizations (loss curves, scatterplots)

3) Allow for both validation and test sets. (If comparing with the Zerveas paper, do not need this functionality.)