### PR TITLE
Relative position encoding variants + baselines

### DIFF
--- a/mvts_transformer/src/datasets/dataset.py
+++ b/mvts_transformer/src/datasets/dataset.py
@@ -132,6 +132,10 @@ def collate_superv(data, max_len=None):
 class ClassiregressionDataset(Dataset):
 
     def __init__(self, data, indices, timestep_indices=None):
+        """
+        timestep_indices is a list of indices specifying which timesteps to use in order
+        (if None, uses all timesteps). This allows one to shuffle/permute the timesteps.
+        """
         super(ClassiregressionDataset, self).__init__()
 
         self.data = data  # this is a subclass of the BaseData class in data.py

--- a/mvts_transformer/src/datasets/dataset.py
+++ b/mvts_transformer/src/datasets/dataset.py
@@ -131,7 +131,7 @@ def collate_superv(data, max_len=None):
 
 class ClassiregressionDataset(Dataset):
 
-    def __init__(self, data, indices):
+    def __init__(self, data, indices, timestep_indices=None):
         super(ClassiregressionDataset, self).__init__()
 
         self.data = data  # this is a subclass of the BaseData class in data.py
@@ -139,6 +139,8 @@ class ClassiregressionDataset(Dataset):
         self.feature_df = self.data.feature_df.loc[self.IDs]
         self.labels_df = self.data.labels_df.loc[self.IDs]
         #self.time_df = self.data.time_df.loc[self.IDs]
+        self.timestep_indices = timestep_indices
+
 
     def __getitem__(self, ind):
         """
@@ -155,6 +157,8 @@ class ClassiregressionDataset(Dataset):
         X = self.feature_df.loc[self.IDs[ind]].values
         y = self.labels_df.loc[self.IDs[ind]].values  # (num_labels,) array
         #time = self.time_df.loc[self.IDs[ind]].values
+        if self.timestep_indices is not None:
+            X = X[self.timestep_indices, :]
 
         return torch.from_numpy(X), torch.from_numpy(y), self.IDs[ind]  #torch.from_numpy(time),
 

--- a/mvts_transformer/src/datasets/dataset.py
+++ b/mvts_transformer/src/datasets/dataset.py
@@ -141,6 +141,10 @@ class ClassiregressionDataset(Dataset):
         #self.time_df = self.data.time_df.loc[self.IDs]
         self.timestep_indices = timestep_indices
 
+        # Calculate the mean/std label
+        self.label_mean = self.labels_df.values.mean()
+        self.label_std = self.labels_df.values.std()
+
 
     def __getitem__(self, ind):
         """

--- a/mvts_transformer/src/main_linear.py
+++ b/mvts_transformer/src/main_linear.py
@@ -1,0 +1,295 @@
+"""
+Simple linaer baseline
+"""
+
+import random
+
+from sklearn.linear_model import Ridge, Lasso
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import GridSearchCV
+from optimizers import get_optimizer
+from models.loss import get_loss_module
+from datasets.datasplit import split_dataset
+from datasets.data import data_factory, Normalizer
+from datasets.utils import process_data
+from utils import utils, visualization_utils
+from running import setup, pipeline_factory, validate, check_progress, NEG_METRICS
+from options import Options
+from torch.utils.tensorboard import SummaryWriter
+from torch.utils.data import DataLoader
+import torch
+from tqdm import tqdm
+import json
+import pickle
+import time
+import sys
+import os
+import logging
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+logging.basicConfig(
+    format="%(asctime)s | %(levelname)s : %(message)s", level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+
+logger.info("Loading packages ...")
+
+# 3rd party packages
+
+# Project modules
+
+
+def main(config):
+    total_epoch_time = 0
+    total_eval_time = 0
+
+    total_start_time = time.time()
+
+    # Add file logging besides stdout
+    file_handler = logging.FileHandler(os.path.join(config["output_dir"], "output.log"))
+    logger.addHandler(file_handler)
+
+    logger.info("Running:\n{}\n".format(" ".join(sys.argv)))  # command used to run
+
+    if config["seed"] is not None:
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Required due to CUBLAS https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility
+        torch.manual_seed(config["seed"])
+        torch.cuda.manual_seed(config["seed"])
+        torch.cuda.manual_seed_all(config["seed"])
+        torch.use_deterministic_algorithms(True)
+        random.seed(config["seed"])
+        np.random.seed(config["seed"])
+
+    device = torch.device(
+        "cuda" if (torch.cuda.is_available() and config["gpu"] != "-1") else "cpu"
+    )
+    config['device'] = device
+    logger.info("Using device: {}".format(device))
+    if device == "cuda":
+        logger.info("Device index: {}".format(torch.cuda.current_device()))
+
+    # Build data
+    logger.info("Loading and preprocessing data ...")
+    data_class = data_factory[config["data_class"]]
+    my_data = data_class(
+        config["data_dir"],
+        pattern=config["pattern"],
+        n_proc=config["n_proc"],
+        limit_size=config["limit_size"],
+        config=config,
+    )
+
+    # Trim data for early prediction
+    proportion = config["proportion"]
+    length = 144
+    if config["baseline"] == 1 and config["proportion"]:
+        trimmed_train_data = my_data.feature_df.iloc[: int(proportion * length)]
+        # every group of 365
+        for i in range(1, int(my_data.feature_df.shape[0] / length)):
+            trimmed_train_data = pd.concat(
+                [
+                    trimmed_train_data,
+                    my_data.feature_df.iloc[
+                        i * length : int((i + proportion) * length)
+                    ],
+                ]
+            )
+
+        my_data.all_df = trimmed_train_data
+        my_data.feature_df = trimmed_train_data
+
+    if config["task"] == "classification":
+        validation_method = "StratifiedShuffleSplit"
+        labels = my_data.labels_df.values.flatten()
+    else:
+        validation_method = "ShuffleSplit"
+        labels = None
+
+    # Split dataset
+    if config['test_pattern'] is None:
+        config['test_pattern'] = 'TEST'
+    test_indices = None
+
+    val_data = my_data
+    val_indices = []
+    test_data = None
+    if config["test_pattern"]:  # used if test data come from different files / file patterns
+        test_data = data_class(config["data_dir"], pattern=config["test_pattern"], n_proc=-1, config=config)
+        test_indices = test_data.all_IDs
+    if config["test_from"]:  # load test IDs directly from file, if available, otherwise use `test_set_ratio`. Can work together with `test_pattern`
+        test_indices = list(set([line.rstrip() for line in open(config["test_from"]).readlines()]))
+        try:
+            test_indices = [int(ind) for ind in test_indices]  # integer indices
+        except ValueError:
+            pass  # in case indices are non-integers
+        logger.info(
+            "Loaded {} test IDs from file: '{}'".format(
+                len(test_indices), config["test_from"]
+            )
+        )
+
+    if config["val_pattern"]:  # used if val data come from different files / file patterns
+        raise ValueError("Validation set not supported for linear.")
+        val_data = data_class(config["data_dir"], pattern=config["val_pattern"], n_proc=-1, config=config)
+        if config["baseline"] == 2 and config["proportion"]:
+            trimmed_val_data = None
+
+            # every group of 365
+            for i in range(int(val_data.feature_df.shape[0] / length)):
+                mean_per_loc = val_data.feature_df.iloc[
+                    i * length : (i + 1) * length
+                ].mean(axis=0)
+                nrows = int((i + proportion) * length) - i * length
+                mean_replicated = pd.DataFrame(
+                    np.repeat(
+                        np.reshape(mean_per_loc.values, (1, 24)), length - nrows, axis=0
+                    )
+                )
+                mean_replicated.columns = val_data.feature_df.columns
+                trimmed_val_data = pd.concat(
+                    [
+                        trimmed_val_data,
+                        val_data.feature_df.iloc[
+                            i * length : int((i + proportion) * length)
+                        ],
+                        mean_replicated,
+                    ]
+                )
+
+            val_data.all_df = trimmed_val_data
+            val_data.feature_df = trimmed_val_data
+
+        val_indices = val_data.all_IDs
+
+    # Note: currently a validation set must exist, either with `val_pattern` or `val_ratio`
+    # Using a `val_pattern` means that `val_ratio` == 0 and `test_ratio` == 0
+    if config["val_ratio"] > 0:
+        raise ValueError("Validation set not supported for linear.")
+        train_indices, val_indices = split_dataset(
+            data_indices=my_data.all_IDs,
+            validation_method=validation_method,
+            n_splits=1,
+            validation_ratio=config["val_ratio"],
+            random_seed=1337,
+            labels=labels,
+        )
+        # `split_dataset` returns a list of indices *per fold/split*
+        train_indices = train_indices[0]
+        # `split_dataset` returns a list of indices *per fold/split*
+        val_indices = val_indices[0]
+    else:
+        train_indices = my_data.all_IDs
+        if test_indices is None:
+            test_indices = []
+
+    logger.info("{} samples may be used for training".format(len(train_indices)))
+    logger.info("{} samples will be used for testing".format(len(test_indices)))
+
+    if config["val_pattern"] != "TEST":
+      assert len(set(train_indices) & set(val_indices)) == 0
+
+    with open(os.path.join(config["output_dir"], "data_indices.json"), "w") as f:
+        try:
+            json.dump(
+                {
+                    "train_indices": list(map(int, train_indices)),
+                    "val_indices": list(map(int, val_indices)),
+                    "test_indices": list(map(int, test_indices)),
+                },
+                f,
+                indent=4,
+            )
+        except ValueError:  # in case indices are non-integers
+            json.dump(
+                {
+                    "train_indices": list(train_indices),
+                    "val_indices": list(val_indices),
+                    "test_indices": list(test_indices),
+                },
+                f,
+                indent=4,
+            )
+
+    # Pre-process features
+    normalizer = None
+    if config["norm_from"]:
+        with open(config["norm_from"], "rb") as f:
+            norm_dict = pickle.load(f)
+        normalizer = Normalizer(**norm_dict)
+    elif config["normalization"] is not None:
+        normalizer = Normalizer(config["normalization"])
+        my_data.feature_df.loc[train_indices] = normalizer.normalize(
+            my_data.feature_df.loc[train_indices]
+        )
+        if not config["normalization"].startswith("per_sample"):
+            # get normalizing values from training set and store for future use
+            norm_dict = normalizer.__dict__
+            with open(
+                os.path.join(config["output_dir"], "normalization.pickle"), "wb"
+            ) as f:
+                pickle.dump(norm_dict, f, pickle.HIGHEST_PROTOCOL)
+    if normalizer is not None:
+        if len(val_indices):
+            val_data.feature_df.loc[val_indices] = normalizer.normalize(
+                val_data.feature_df.loc[val_indices]
+            )
+        if len(test_indices):
+            test_data.feature_df.loc[test_indices] = normalizer.normalize(
+                test_data.feature_df.loc[test_indices]
+            )
+
+    print("Train data", my_data.feature_df.loc[train_indices].shape, my_data.labels_df.loc[train_indices].shape)
+    print("Test data", test_data.feature_df.loc[test_indices].shape, test_data.labels_df.loc[test_indices].shape)
+
+    X_train = np.empty((len(train_indices), my_data.max_seq_len, my_data.feature_df.shape[1]))
+    for i, train_idx in enumerate(train_indices):
+        X_train[i] = my_data.feature_df.loc[train_idx]  # RHS is [timesteps, variables]
+    X_test = np.empty((len(test_indices), my_data.max_seq_len, my_data.feature_df.shape[1]))
+    for i, test_idx in enumerate(test_indices):
+        X_test[i] = test_data.feature_df.loc[test_idx]
+    Y_train = my_data.labels_df.loc[train_indices].to_numpy()
+    Y_test = test_data.labels_df.loc[test_indices].to_numpy()
+    print("Shape test", X_train.shape, X_test.shape, Y_train.shape, Y_test.shape)  # X: [n_examples, n_timsteps, n_vars]  Y: [n_examples]
+
+    # Flatten
+    #X_train = X_train.mean(axis=1)
+    #X_test = X_test.mean(axis=1)
+    X_train = X_train.reshape((X_train.shape[0], -1))
+    X_test = X_test.reshape((X_test.shape[0], -1))
+    Y_train = Y_train.flatten()
+    Y_test = Y_test.flatten()
+    print("Shape test after flatten", X_train.shape, X_test.shape, Y_train.shape, Y_test.shape)
+
+
+    # Train model
+    if args.model == "ridge":
+        model = Ridge(random_state=args.seed)
+        hyperparams = {"alpha": [0, 0.01, 0.1, 1, 10, 100, 1000]}
+    elif args.model == "lasso":
+        model = Lasso(random_state=args.seed)
+        hyperparams = {"alpha": [0, 0.01, 0.1, 1, 10, 100, 1000]}
+    regressor = GridSearchCV(model, hyperparams, cv=10)
+    regressor = regressor.fit(X_train, Y_train)
+    predictions_test = regressor.predict(X_test)
+    rmse_test = np.sqrt(mean_squared_error(Y_test, predictions_test))
+    print("RMSE", rmse_test)
+    coefs = regressor.best_estimator_.coef_.reshape((my_data.max_seq_len, my_data.feature_df.shape[1]))
+    print("Coefs", coefs.shape, coefs)
+
+    # Visualizations
+    visualization_utils.plot_single_scatter_file(predictions_test, Y_test, "predicted", "true", config['plot_dir'],
+                                                 title_description=f"{config['model']} flattened",
+                                                 filename_description="test", should_align=True)
+
+    # Plot time series
+    visualization_utils.plot_time_series(coefs, os.path.join(config['plot_dir'], f"{config['model']}_coefs.png"))
+    visualization_utils.plot_time_series(X_train[0].reshape((my_data.max_seq_len, my_data.feature_df.shape[1])),
+                                         os.path.join(config['plot_dir'], f"{config['model']}_example_x0.png"))
+
+
+if __name__ == "__main__":
+    args = Options().parse()  # `argsparse` object
+    config = setup(args)  # configuration dictionary
+    main(config)

--- a/mvts_transformer/src/main_linear.py
+++ b/mvts_transformer/src/main_linear.py
@@ -1,5 +1,5 @@
 """
-Simple linaer baseline
+Simple linear regression baselines only
 """
 
 import random

--- a/mvts_transformer/src/models/ClimaX/pos_embed.py
+++ b/mvts_transformer/src/models/ClimaX/pos_embed.py
@@ -47,7 +47,7 @@ def get_2d_sincos_pos_embed_from_grid(embed_dim, grid):
     return emb
 
 
-def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
+def get_1d_sincos_pos_embed_from_grid(embed_dim, pos, max_len=None):
     """
     embed_dim: output dimension for each position
     pos: a list of positions to be encoded: size (M,)
@@ -57,6 +57,10 @@ def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
     omega = np.arange(embed_dim // 2, dtype=float)  # np.float) @joshuafan changed np.float -> float
     omega /= embed_dim / 2.0
     omega = 1.0 / 10000**omega  # (D/2,)
+
+    # TAPE modifcation: modulate by sequence length.
+    if max_len is not None:
+        omega = omega * (embed_dim / max_len)
 
     pos = pos.reshape(-1)  # (M,)
     out = np.einsum("m,d->md", pos, omega)  # (M, D/2), outer product

--- a/mvts_transformer/src/models/local_cnn.py
+++ b/mvts_transformer/src/models/local_cnn.py
@@ -1,0 +1,121 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def model_factory(config, data):
+    task = config['task']
+    feat_dim = data.feature_df.shape[1]  # dimensionality of data features
+    # data windowing is used when samples don't have a predefined length or the length is too long
+    max_seq_len = config['data_window_len'] if config['data_window_len'] is not None else config['max_seq_len']
+    if max_seq_len is None:
+        try:
+            max_seq_len = data.max_seq_len
+        except AttributeError as x:
+            print("Data class does not define a maximum sequence length, so it must be defined with the script argument `max_seq_len`")
+            raise x
+
+    if (task == "imputation") or (task == "transduction"):
+        raise NotImplementedError()
+    if (task == "classification") or (task == "regression"):
+        # dimensionality of labels
+        num_labels = len(
+            data.class_names) if task == "classification" else data.labels_df.shape[1]
+        if config['model'] == 'local_cnn':
+            return LocalCNN(in_channels=feat_dim, max_len=max_seq_len, num_classes=num_labels, final_emb_dim=config['d_model'],
+                            conv_type=config['conv_type'], pool=config['pool'])
+        else:
+            raise ValueError("Unsupported model", config['model'])
+    else:
+        raise ValueError("Model class for task '{}' does not exist".format(task))
+
+class LocalCNN(nn.Module):
+    def __init__(self, in_channels, max_len=144, num_classes=1, final_emb_dim=512, conv_type="hierarchical", pool="seqpool"):
+        """
+        conv_type can be hierarchical or local
+
+        pool can be seqpool (attention pooling in Compact Convolutional Transformer paper),
+        average, or linear.
+        """
+        super().__init__()
+        self.in_channels = in_channels
+        self.max_len = max_len
+        self.num_classes = num_classes
+        self.final_emb_dim = final_emb_dim
+        self.conv_type = conv_type
+        self.pool = pool
+
+        if self.conv_type == "hierarchical":  # Gradually reduces number of timesteps
+            self.conv = nn.Sequential(
+                nn.Conv1d(in_channels=in_channels, out_channels=64, kernel_size=5, stride=1),
+                nn.ReLU(),
+                nn.AvgPool1d(kernel_size=2, stride=2),
+                nn.Conv1d(64, 128, 3, 1),
+                nn.ReLU(),
+                nn.AvgPool1d(2, 2),
+                nn.Conv1d(128, 256, 3, 1),
+                nn.ReLU(),
+                nn.AvgPool1d(2, 2),
+                nn.Conv1d(256, final_emb_dim, 3, 1),
+                nn.AvgPool1d(2, 2),
+            )
+        elif self.conv_type == "local":  # No reducing number of timesteps
+            self.conv = nn.Sequential(
+                nn.Conv1d(in_channels=in_channels, out_channels=64, kernel_size=5, stride=1, padding='same'),
+                nn.BatchNorm1d(64),
+                nn.ReLU(),
+                nn.Conv1d(64, 128, 5, 1, padding='same'),
+                nn.BatchNorm1d(128),
+                nn.ReLU(),
+                nn.Conv1d(128, 256, 5, 1, dilation=3, padding='same'),
+                nn.BatchNorm1d(256),
+                nn.ReLU(),
+                nn.Conv1d(256, final_emb_dim, 5, 1, dilation=5, padding='same'),
+            )
+        else:
+            raise ValueError("invalid conv_type")
+
+        if self.pool == "seqpool":
+            self.attention_pool = nn.Linear(final_emb_dim, 1)
+            self.fc = nn.Linear(final_emb_dim, num_classes)
+        elif self.pool == "average":
+            self.fc = nn.Sequential(
+                nn.AdaptiveAvgPool1d(1),
+                nn.Flatten(),
+                nn.Linear(final_emb_dim, num_classes)
+            )
+        elif self.pool == "linear":
+            # Hack to fetch dimensions of CNN's output
+            # TODO I recall there is a better way to do this, but could not find yet
+            input = torch.randn((1, in_channels, max_len))  # [batch, channel, time]. Conv expects this order
+            output = self.conv(input)  # [batch, channel, time]
+            self.fc = nn.Sequential(
+                nn.Flatten(),  # Default converts to [batch, channel*time]
+                nn.Linear(output.shape[1]*output.shape[2], num_classes)
+            )
+        else:
+            raise ValueError("invalid pool")
+
+    def forward(self, x, plot_dir=None):
+        """
+        x should have shape [batch, time, channel]
+        """
+        x = x.permute((0, 2, 1))  # Convert to [batch, channel, time]
+        x = self.conv(x)   # Convert to [batch, channel, time']  (may be fewer timesteps)
+        if self.pool == "seqpool":
+            x = x.permute((0, 2, 1))  # Convert back to [batch, time, channel]. For each example & timestep, use all channels to predict an attention score
+
+            # Code from https://github.com/SHI-Labs/Compact-Transformers/blob/main/src/utils/transformers.py#L208
+            # attention_pool outputs [batch, time, 1].
+            # Softmax normalizes it so that sum across the time dimension (for each example) is 1.
+            # Transpose it to [batch, 1, time], and then multiply with [batch, time, channel] -> [batch, 1, channel].
+            # Squeeze out the 1 to get [batch, channel].
+            # TODO add a positional encoding
+            x = torch.matmul(F.softmax(self.attention_pool(x), dim=1).transpose(-1, -2), x).squeeze(-2)
+            x = self.fc(x)
+        elif self.pool in ["average", "linear"]:
+            x = self.fc(x)
+        else:
+            raise ValueError("Invalid pool")
+        return x
+

--- a/mvts_transformer/src/models/ts_climax.py
+++ b/mvts_transformer/src/models/ts_climax.py
@@ -17,6 +17,7 @@ from models.ClimaX.pos_embed import (
     get_1d_sincos_pos_embed_from_grid,
     get_2d_sincos_pos_embed,
 )
+from utils import visualization_utils
 
 def model_factory(config, data):
     task = config['task']
@@ -50,6 +51,9 @@ def model_factory(config, data):
                           pos_encoding=config['pos_encoding'],
                           relative_pos_encoding=config['relative_pos_encoding'],
                           agg_vars=config['agg_vars'],
+                          conv_transformer=config['conv_transformer'],
+                          where_to_add_relpos=config['where_to_add_relpos'],
+                          conv_projection=config['conv_projection'],
                           local_mask=config['local_mask'])
     else:
         raise ValueError("Model class for task '{}' does not exist".format(task))
@@ -109,7 +113,10 @@ class ClimaX(nn.Module):
         pos_encoding='learnable_init_sin',
         relative_pos_encoding='none',
         agg_vars=False,
-        local_mask=-1,
+        conv_transformer=False,
+        where_to_add_relpos=False,
+        conv_projection=False,
+        local_mask=-1
     ):
         super().__init__()
 
@@ -121,8 +128,11 @@ class ClimaX(nn.Module):
         self.pos_encoding = pos_encoding
         self.relative_pos_encoding = relative_pos_encoding
         self.agg_vars = agg_vars
+        self.conv_transformer = conv_transformer
         self.device = device
         self.local_mask = local_mask
+        self.where_to_add_relpos = where_to_add_relpos
+        self.conv_projection = conv_projection
 
         # variable tokenization: separate embedding layer for each input variable
 
@@ -136,11 +146,29 @@ class ClimaX(nn.Module):
             self.var_embed = self.create_var_embedding(embed_dim)
             self.var_query = nn.Parameter(torch.zeros(1, 1, embed_dim), requires_grad=True)
             self.var_agg = nn.MultiheadAttention(embed_dim, num_heads, batch_first=True)
+            seq_len = int((max_seq_len - patch_size) / stride + 1)
+
+        elif self.conv_transformer:
+            # # Convolutional encoder
+            # self.embed_layer = nn.Sequential(
+            #     nn.Conv2d(1, embed_dim*4, kernel_size=[1, patch_size], padding='same'),
+            #     nn.BatchNorm2d(embed_dim*4),
+            #     nn.GELU(),
+            #     nn.Conv2d(embed_dim*4, embed_dim, kernel_size=[self.img_size[1], 1], padding='valid'),
+            #     nn.BatchNorm2d(embed_dim),
+            #     nn.MaxPool2d(kernel_size=[1, stride], stride=[1, stride]),
+            #     nn.GELU()
+            # )
+
+            self.embed_layer = ConvEmbed(patch_size, img_size[1], embed_dim,
+                                         stride, padding=int(np.ceil((patch_size-stride)/2)),  # Ensures that num_patches is num_timesteps/stride
+                                         norm_layer=nn.BatchNorm1d)
+            seq_len = int(max_seq_len // stride)
         else:
             self.embed_layer = nn.Linear(patch_size*img_size[1], embed_dim)  # each patch has patch_size*num_variables elements
 
-        # Number of tokens (patches) in the time dimension
-        seq_len = int((max_seq_len - patch_size) / stride + 1)
+            # Number of tokens (patches) in the time dimension
+            seq_len = int((max_seq_len - patch_size) / stride + 1)
         self.seq_len = seq_len
 
         # positional embedding
@@ -187,8 +215,12 @@ class ClimaX(nn.Module):
         # self.head.append(nn.Linear(embed_dim, embed_dim // 2))
         # self.head = nn.Sequential(*self.head)
 
-        encoder_layer = TransformerBatchNormEncoderLayer(
-                embed_dim, num_heads, feedforward_dim, drop_rate * (1.0 - freeze))
+        if self.conv_transformer:
+            encoder_layer = ConvTransformerBlock(embed_dim, num_heads, patch_size,
+                                                 feedforward_dim, drop_rate * (1.0 - freeze))
+        else:
+            encoder_layer = TransformerBatchNormEncoderLayer(
+                embed_dim, num_heads, feedforward_dim, drop_rate * (1.0 - freeze), where_to_add_relpos=where_to_add_relpos, conv_projection=conv_projection)
         self.transformer_encoder = TransformerEncoder(encoder_layer, depth)
         # self.head_linear = nn.Linear(embed_dim, embed_dim // 2)
 
@@ -201,13 +233,13 @@ class ClimaX(nn.Module):
 
         # final linear layer
         # self.output_layer = nn.Linear(embed_dim // 2 * int((max_seq_len - patch_size) / stride + 1), num_classes)
-        self.output_layer = nn.Linear(embed_dim * int((max_seq_len - patch_size) / stride + 1), num_classes)
+        self.output_layer = nn.Linear(embed_dim * seq_len, num_classes)
 
         # Local mask. Restrict which pairs of timesteps can pay attention to each other
         if self.local_mask >= 0:
 
             # Note that if relative positional encoding is being used, this is redundant with "relative_coords"
-            indices = torch.arange(0, int((max_seq_len - patch_size) / stride + 1))
+            indices = torch.arange(0, seq_len, device=device)
             distance_matrix = torch.abs(indices.reshape((1, -1)) - indices.reshape((-1, 1)))  # [seq_len, seq_len]
             self.invalid_mask = torch.zeros((len(indices), len(indices))).bool()  # [seq_len, seq_len]
             self.invalid_mask[distance_matrix > self.local_mask] = True
@@ -228,7 +260,16 @@ class ClimaX(nn.Module):
             self.pos_embed = nn.Parameter(torch.zeros(seq_len, emb_dim), requires_grad=True)
             pos_embed = get_1d_sincos_pos_embed_from_grid(
                 self.pos_embed.shape[-1],
-                np.arange(int((self.max_len - self.patch_size) / self.stride + 1))
+                np.arange(seq_len)
+            )
+            self.pos_embed.data.copy_(torch.from_numpy(pos_embed).float())
+        elif pos_encoding == "learnable_tape_init":
+            # Simple learnable vector for each position, initialized with sinusoidal features (using TAPE trick to determine frequencies)
+            self.pos_embed = nn.Parameter(torch.zeros(seq_len, emb_dim), requires_grad=True)
+            pos_embed = get_1d_sincos_pos_embed_from_grid(
+                self.pos_embed.shape[-1],
+                np.arange(seq_len),
+                max_len = seq_len
             )
             self.pos_embed.data.copy_(torch.from_numpy(pos_embed).float())
         elif pos_encoding == "fixed":
@@ -273,12 +314,23 @@ class ClimaX(nn.Module):
             relative_coords = coords_t[:, None] - coords_t[None, :]  # [seq_len, seq_len]. Each entry (i, j) contains (i-j)
             relative_coords += seq_len - 1  # shift to start from 0
             self.register_buffer("relative_coords", relative_coords)
+
+        elif relative_pos_encoding == "erpe_symmetric":
+            # eRPE: learnable bias for each relative offset between timesteps
+            # define a parameter table of relative position bias
+            self.relative_bias_table = nn.Parameter(torch.zeros(seq_len, num_heads), requires_grad=True)  # Relative offsets range from (0) to -(seq_len-1), inclusive
+
+            # get pair-wise relative position index for each token inside the window
+            coords_t = torch.arange(seq_len, device=self.device)
+            relative_coords = torch.abs(coords_t[:, None] - coords_t[None, :])  # [seq_len, seq_len]. Each entry (i, j) contains |i-j|
+            self.register_buffer("relative_coords", relative_coords)
+
         elif relative_pos_encoding == "erpe_alibi_init":
             # Calculate initial bias table using ALIBI linear functions for each head. Note that the linaer function is multiplying "slope" with absolute |distance|.
             slopes = torch.tensor(get_slopes(num_heads), device=self.device)*-1  # [num_heads]
             bias_table_init = torch.zeros(2*seq_len-1, num_heads)
-            bias_table_init[0:self.seq_len-1] = torch.arange(start=self.seq_len-1, end=0, step=-1, device=self.device).unsqueeze(1) * slopes
-            bias_table_init[self.seq_len-1:] = torch.arange(start=0, end=self.seq_len, device=self.device).unsqueeze(1) * slopes
+            bias_table_init[0:seq_len-1] = torch.arange(start=seq_len-1, end=0, step=-1, device=self.device).unsqueeze(1) * slopes
+            bias_table_init[seq_len-1:] = torch.arange(start=0, end=seq_len, device=self.device).unsqueeze(1) * slopes
             self.relative_bias_table = nn.Parameter(bias_table_init, requires_grad=True)  # Relative offsets range from (seq_len-1) to -(seq_len-1), inclusive
 
             # get pair-wise relative position index for each token inside the window
@@ -286,6 +338,32 @@ class ClimaX(nn.Module):
             relative_coords = coords_t[:, None] - coords_t[None, :]  # [seq_len, seq_len]. Each entry (i, j) contains (i-j)
             relative_coords += seq_len - 1  # shift to start from 0
             self.register_buffer("relative_coords", relative_coords)
+        elif relative_pos_encoding == "custom_rpe":
+            convit_heads = num_heads // 2
+            normal_heads = num_heads - convit_heads
+
+            # These heads just have purely learnable positional embeddings
+            self.normal_biases = nn.Parameter(torch.zeros(2*seq_len-1, normal_heads), requires_grad=True)  # Relative offsets range from (seq_len-1) to -(seq_len-1), inclusive
+            self.convit_slopes = nn.Parameter(torch.tensor([0.5 for i in range(convit_heads)], device=self.device), requires_grad=True)
+            self.convit_intercepts = nn.Parameter(torch.zeros((convit_heads), device=self.device), requires_grad=True)
+            self.convit_offsets = nn.Parameter(torch.tensor([-1 * (2.0 ** i) for i in range(convit_heads//2)] +
+                                                            [2.0 ** i for i in range(convit_heads//2)], device=self.device), requires_grad=True)
+
+            # #self.alibi_slopes = nn.Parameter(torch.tensor(get_slopes(alibi_heads), device=self.device), requires_grad=True)
+            # self.convit_slopes = nn.Parameter(torch.tensor([0.1 for i in range(convit_heads)], device=self.device), requires_grad=True)
+            # #self.alibi_intercepts = nn.Parameter(torch.zeros((alibi_heads), device=self.device), requires_grad=True)
+            # self.convit_slopes = torch.tensor([0.1 for i in range(convit_heads)], device=self.device)
+            # self.convit_intercepts = torch.zeros((convit_heads), device=self.device)
+            # self.convit_offsets = torch.tensor([-1 * (2.0 ** i) for i in range(convit_heads//2)] +
+            #                                    [2.0 ** i for i in range(convit_heads//2)], device=self.device)
+            # bias_init[:, -convit_heads:] = -1.0 * self.convit_slopes * torch.abs(torch.arange(0, 2*self.seq_len-1, device=self.device).unsqueeze(1) - (self.seq_len-1+self.convit_offsets)) + self.convit_intercepts # Distance to "focus pixel", [2*seq_len-1, num_convit_heads]
+            # self.relative_bias_table = nn.Parameter(bias_init, requires_grad=True)
+            # get pair-wise relative position index for each token inside the window
+            coords_t = torch.arange(seq_len, device=self.device)
+            relative_coords = coords_t[:, None] - coords_t[None, :]  # [seq_len, seq_len]. Each entry (i, j) contains (i-j)
+            relative_coords += seq_len - 1  # shift to start from 0
+            self.register_buffer("relative_coords", relative_coords)
+
         elif relative_pos_encoding == "alibi":
             # FIXED bias for relative offsets. Each head has a different function.
             # Code from https://github.com/ofirpress/attention_with_linear_biases/issues/5
@@ -331,7 +409,7 @@ class ClimaX(nn.Module):
                 plt.savefig(os.path.join(plot_dir, f'{file_prefix}_absolute_pos_encoding_distances.png'))
                 plt.close()
 
-        if "erpe" in self.relative_pos_encoding:
+        if "erpe" in self.relative_pos_encoding or self.relative_pos_encoding == "custom_rpe":
             # self.relative_bias_table has shape [2*seq_len-1, num_heads]
             rel_smoothness = ((self.relative_bias_table[1:, :] - self.relative_bias_table[:-1, :]) ** 2).mean()
             smoothness_loss += rel_smoothness
@@ -361,7 +439,8 @@ class ClimaX(nn.Module):
 
     def _init_weights(self, m):
         if isinstance(m, nn.Linear):
-            trunc_normal_(m.weight, std=0.02)
+            nn.init.xavier_uniform_(m.weight)
+            # trunc_normal_(m.weight, std=0.02)
             if m.bias is not None:
                 nn.init.constant_(m.bias, 0)
         elif isinstance(m, nn.LayerNorm):
@@ -391,8 +470,36 @@ class ClimaX(nn.Module):
 
         return x
 
-    def forward_encoder(self, x: torch.Tensor):
+    def forward_encoder(self, x: torch.Tensor, plot_dir: str = None):
         # x: `[B, T, V]` shape.
+
+        if plot_dir is not None:
+            # Plot an example input and distances between timesteps (just for comparison with later)
+            x_detached = x.detach().cpu()
+            visualization_utils.plot_time_series(x_detached[0, :, :].numpy(), os.path.join(plot_dir, 'example_x0.png'))
+            n_rows = 5  # Examples to plot
+            n_cols = 1
+
+            # Plot Euclidean distance between timestep feature vectors
+            feature_distances = torch.linalg.norm(x_detached.unsqueeze(1) - x_detached.unsqueeze(2), dim=3)  # [batch, time, time]
+            # feature_distances_manual = torch.zeros((x.shape[0], x.shape[1], x.shape[1]), device=x.device)
+            # for i in range(x.shape[0]):
+            #     for j in range(x.shape[1]):
+            #         for k in range(x.shape[1]):
+            #             feature_distances_manual[i, j, k] = torch.linalg.norm(x[i, j, :] - x[i, k, :])
+            # assert torch.allclose(feature_distances, feature_distances_manual)
+
+            min_value, max_value = torch.min(feature_distances), torch.max(feature_distances)
+            fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2*n_cols, 2*n_rows))
+            for r in range(n_rows):
+                im = axeslist[r].imshow(feature_distances[r, :, :].detach().cpu().numpy(), vmin=min_value, vmax=max_value)
+                if r == 0:
+                    axeslist[r].set_title(f"Input")
+            plt.tight_layout(rect=[0, 0.03, 0.95, 0.95])
+            plt.colorbar(im)
+            plt.suptitle("Distance between timestep INPUTS")
+            plt.savefig(os.path.join(plot_dir, 'timestep_input_distances.png'))
+            plt.close()
 
         if self.agg_vars:
             # tokenize each variable separately
@@ -408,6 +515,10 @@ class ClimaX(nn.Module):
             # variable aggregation
             x = self.aggregate_variables(x)  # B, L, D
 
+        elif self.conv_transformer:
+            x = x.permute(0, 2, 1) # B, V, T  [batch, vars, time]
+            x = self.embed_layer(x)  # [batch, embed_dim, num_patches]
+            x = x.permute(0, 2, 1)  # [batch, num_patches (seq_len), embed_dim]
         else:
             x = x.permute(0, 2, 1) # B, V, T
             x = x.unfold(dimension=-1, size=self.patch_size, step=self.stride) # B, V, num_patches, patch_size
@@ -417,8 +528,9 @@ class ClimaX(nn.Module):
 
         # Add ABSOLUTE pos embedding if using.
         # At this point, X should be [batch, seq_len, embed_dim], and pos_embed should be [seq_len, embed_dim]. (seq_len = number of patches along time dimension)
-        x = x + self.pos_embed
-        x = self.pos_drop(x)
+        if self.pos_embed is not None:
+            x = x + self.pos_embed
+            x = self.pos_drop(x)
 
         # apply Transformer blocks. NOT USED ANYMORE
         # for blk in self.blocks:
@@ -426,7 +538,7 @@ class ClimaX(nn.Module):
 
         # Construct mask for relative positional encoding.
         offset_mask = None
-        if "erpe" in self.relative_pos_encoding:
+        if "erpe" in self.relative_pos_encoding:  # erpe_symmetric can use the same code since we set "relative_coords" to use absolute distances
             # self.relative_bias_table: [2*seq_len-1, num_heads]
             # self.relative_coords: [seq_len, seq_len] - ID of offset between timesteps
             # To construct relative embedding matrix, flatten the "offset matrix" (relative_coords),
@@ -436,6 +548,19 @@ class ClimaX(nn.Module):
             flattened_indices = self.relative_coords.flatten()  # [seq_len*seq_len]
             offset_mask = self.relative_bias_table.index_select(dim=0, index=flattened_indices).reshape(self.seq_len, self.seq_len, num_heads)  # [seq_len, seq_len, heads]
             offset_mask = offset_mask.permute(2, 0, 1).repeat((x.shape[0], 1, 1))  # [batch*num_heads, seq_len, seq_len]
+        elif self.relative_pos_encoding == "custom_rpe":
+            # # Set up bias table
+            # #alibi_biases = -1.0 * self.alibi_slopes * torch.abs(torch.arange(0, 2*self.seq_len-1, device=self.device).unsqueeze(1) - (self.seq_len-1)) + self.alibi_intercepts # Distance to myself, [2*seq_len-1, num_alibi_heads]
+            convit_biases = -1.0 * self.convit_slopes * torch.abs(torch.arange(0, 2*self.seq_len-1, device=self.device).unsqueeze(1) - (self.seq_len-1+self.convit_offsets)) + self.convit_intercepts # Distance to "focus pixel", [2*seq_len-1, num_convit_heads]
+            bias_table = torch.cat([self.normal_biases, convit_biases], dim=1)
+            self.relative_bias_table = bias_table
+
+            # Compute the actual offset matrix
+            num_heads = self.relative_bias_table.shape[1]
+            flattened_indices = self.relative_coords.flatten()  # [seq_len*seq_len]
+            offset_mask = self.relative_bias_table.index_select(dim=0, index=flattened_indices).reshape(self.seq_len, self.seq_len, num_heads)  # [seq_len, seq_len, heads]
+            offset_mask = offset_mask.permute(2, 0, 1).repeat((x.shape[0], 1, 1))  # [batch*num_heads, seq_len, seq_len]
+
         elif self.relative_pos_encoding == "alibi":
             offset_mask = self.alibi.repeat((x.shape[0], 1, 1))  # Repeat along the batch dimension, as PyTorch expects mask to be [batch*num_heads, seq_len, seq_len]
 
@@ -447,25 +572,22 @@ class ClimaX(nn.Module):
             else:
                 offset_mask[self.invalid_mask] = float("-inf")
 
-        # Change to [seq_len, batch, embed_dim] to align with Pytorch convention
-        x = x.permute((1, 0, 2))
-
-        x, attn_weights = self.transformer_encoder(x, mask=offset_mask)  # after encoder. x: [seq_len, batch, embed_dim]. attn_weights: [batch, n_layer*n_head, seq_len, seq_len]
+        x, attn_weights = self.transformer_encoder(x, mask=offset_mask, plot_dir=plot_dir)  # after encoder. x: [batch, seq_len, embed_dim]. attn_weights: [batch, n_layer*n_head, seq_len, seq_len]
         # x = self.head_linear(x)
         # x = self.norm(x)
 
-        x = x.permute((1, 0, 2))  # Permute back to [batch, seq_len, embed_dim]
         return x, attn_weights
 
-    def forward(self, x):
+    def forward(self, x, plot_dir=None):
         """Forward pass through the model.
 
         Args:
             x: `[batch_size, seq_length, feat_dim]` shape.
+            plot_dir: if provided, plot attention matrices and distances between timestep feature vectors at each layer.
         Returns:
             preds (torch.Tensor): `[B]` shape. Predicted output.
         """
-        preds, attn_weights = self.forward_encoder(x)
+        preds, attn_weights = self.forward_encoder(x, plot_dir=plot_dir)
         preds = self.act(preds)
         preds = self.dropout1(preds)
         preds = preds.reshape(preds.shape[0], -1)
@@ -503,13 +625,14 @@ class TransformerEncoder(nn.modules.Module):
         self.enable_nested_tensor = enable_nested_tensor
         self.mask_check = mask_check
 
-    def forward(self, src: Tensor, mask: Optional[Tensor] = None, src_key_padding_mask: Optional[Tensor] = None) -> Tensor:
+    def forward(self, src: Tensor, mask: Optional[Tensor] = None, src_key_padding_mask: Optional[Tensor] = None, plot_dir: str = None) -> Tensor:
         r"""Pass the input through the encoder layers in turn.
 
         Args:
-            src: the sequence to the encoder (required). Must be of shape [TIME, BATCH, EMBED_DIM]
+            src: the sequence to the encoder (required). Must be of shape [BATCH, TIME, EMBED_DIM]
             mask: the mask for the src sequence (optional).
             src_key_padding_mask: the mask for the src keys per batch (optional).
+            plot_dir: if provided, plot attention matrices and distances between timestep feature vectors
 
         Shape:
             see the docs in Transformer class.
@@ -588,12 +711,87 @@ class TransformerEncoder(nn.modules.Module):
                 src_key_padding_mask_for_layers = None
 
         attn_weights_layers = None
+
+        # DEBUGGING: Compute Euclidean distance between each timestep's feature vectors. "output" is assumed to be shape [batch, seq_len, embed_dim].
+        # Via broadcasting, we convert this to [batch, seq_len, seq_len, embed_dim], then take the norm over embed_dim.
+        # Result is [batch, seq_len, seq_len]
+        feat_detached = output.detach().cpu()
+        feature_distances_layers = [torch.linalg.norm(feat_detached.unsqueeze(1) - feat_detached.unsqueeze(2), dim=3)]
+
+        # DEBUGGING: Compute cosine similarity between each timestep's feature vectors. "output" is assumed to be shape [batch, seq_len, embed_dim].
+        # Via broadcasting, we convert this to [batch, seq_len, seq_len, embed_dim], then compute similarity over embed_dim.
+        # Result is [batch, seq_len, seq_len]
+        # See https://pytorch.org/docs/stable/generated/torch.nn.functional.cosine_similarity.html
+        similarity_matrix_layers = [F.cosine_similarity(feat_detached.unsqueeze(1), feat_detached.unsqueeze(2), dim=3)]
+
+        # Compute forward pass
         for mod in self.layers:
-            output, attn_weights = mod(output, src_mask=mask, src_key_padding_mask=src_key_padding_mask_for_layers)  # output: [seq_len, batch, embed_dim], attn_weights: [batch, num_heads, seq_len, seq_len]
+            output, attn_weights = mod(output, src_mask=mask, src_key_padding_mask=src_key_padding_mask_for_layers, plot_dir=plot_dir)  # output: [batch, seq_len, embed_dim], attn_weights: [batch, num_heads, seq_len, seq_len]
             if attn_weights_layers is None:
               attn_weights_layers = attn_weights
             else:
               attn_weights_layers = torch.cat((attn_weights_layers, attn_weights), dim=1)  # attn_weights: [batch, n_layers*num_heads, seq_len, seq_len]
+
+            # DEBUGGING: Compute distances between timestep feature vectors
+            feat_detached = output.detach().cpu()
+            feature_distances_layers.append(torch.linalg.norm(feat_detached.unsqueeze(1) - feat_detached.unsqueeze(2), dim=3))
+            similarity_matrix_layers.append(F.cosine_similarity(feat_detached.unsqueeze(1), feat_detached.unsqueeze(2), dim=3))
+
+        # VISUALIZATIONS
+        if plot_dir is not None:
+            n_rows = 5  # Examples to plot
+
+            # Plot Euclidean distance between timestep feature vectors
+            n_cols = len(feature_distances_layers)
+            feature_distances_layers = torch.stack(feature_distances_layers, dim=1)  # Convert this to similar format as attn_weights_layers [batch, n_matrices, seq_len, seq_len]
+            min_value, max_value = torch.min(feature_distances_layers), torch.max(feature_distances_layers)
+            fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2*n_cols, 2*n_rows))
+            for r in range(n_rows):
+                for c in range(n_cols):
+                    im = axeslist[r, c].imshow(feature_distances_layers[r, c, :, :].detach().cpu().numpy(), vmin=min_value, vmax=max_value)
+                    if r == 0:
+                        if c < n_cols-1:
+                            axeslist[r, c].set_title(f"Before layer {c+1}")
+                        else:
+                            axeslist[r, c].set_title(f"Final")
+            plt.tight_layout(rect=[0, 0.03, 0.95, 0.95])
+            plt.colorbar(im)
+            plt.suptitle("Distance between timestep feature vectors")
+            plt.savefig(os.path.join(plot_dir, 'timestep_distances.png'))
+            plt.close()
+
+            # Plot cosine similarity between timestep feature vectors
+            n_cols = len(similarity_matrix_layers)
+            similarity_matrix_layers = torch.stack(similarity_matrix_layers, dim=1)  # Convert this to similar format as attn_weights_layers [batch, n_matrices, seq_len, seq_len]
+            min_value, max_value = torch.min(similarity_matrix_layers), torch.max(similarity_matrix_layers)
+            fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2*n_cols, 2*n_rows))
+            for r in range(n_rows):
+                for c in range(n_cols):
+                    im = axeslist[r, c].imshow(similarity_matrix_layers[r, c, :, :].detach().cpu().numpy(), vmin=min_value, vmax=max_value)
+                    if r == 0:
+                        if c < n_cols-1:
+                            axeslist[r, c].set_title(f"Before layer {c+1}")
+                        else:
+                            axeslist[r, c].set_title(f"Final")
+            plt.tight_layout(rect=[0, 0.03, 0.95, 0.95])
+            plt.colorbar(im)
+            plt.suptitle("Cos similarity between timestep feature vectors")
+            plt.savefig(os.path.join(plot_dir, 'timestep_similarities.png'))
+            plt.close()
+
+            # Plot attention matrices
+            n_matrices = attn_weights_layers.shape[1]  # Total number of attention maps per example (n_layers*n_heads)
+            n_cols = n_matrices//2
+            fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2*n_cols, 2*n_rows))
+
+            for r in range(n_rows):
+                for c in range(n_cols):
+                    im = axeslist[r, c].imshow(attn_weights_layers[r, c*(n_matrices//n_cols), :, :].detach().cpu().numpy(), vmin=0, vmax=3/attn_weights_layers.shape[2])  #0/attn_weights_layers.shape[1])
+            plt.tight_layout(rect=[0, 0.03, 0.95, 0.95])
+            plt.colorbar(im)
+            plt.suptitle("Example attention matrices")
+            plt.savefig(os.path.join(plot_dir, 'attention_matrices.png'))
+            plt.close()
 
         if convert_to_nested:
             output = output.to_padded_tensor(0.)
@@ -616,9 +814,16 @@ class TransformerBatchNormEncoderLayer(nn.modules.Module):
         activation: the activation function of intermediate layer, relu or gelu (default=relu).
     """
 
-    def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1):
+    def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1, where_to_add_relpos=False, conv_projection=False):
         super(TransformerBatchNormEncoderLayer, self).__init__()
-        self.self_attn = MultiheadAttention(d_model, nhead, dropout=dropout)
+        if where_to_add_relpos == "before":
+            # Note: we could also use Attention_Rel_Scl here. TODO - check that they behave the same way
+            self.self_attn = MultiheadAttention(d_model, nhead, dropout=dropout, batch_first=True)  # TEMPORARY only for bugfix, batch_first=True)
+            assert conv_projection == False, "conv_projection is only supported for custom attention (Attention_Rel_Scl)"
+        else:
+            # Custom attention if we want relative position offset to be applied after softmax
+            self.self_attn = Attention_Rel_Scl(d_model, nhead, dropout=dropout, conv_projection=conv_projection, where_to_add_relpos=where_to_add_relpos)
+
         # Implementation of Feedforward model
         self.linear1 = Linear(d_model, dim_feedforward)
         self.dropout = Dropout(dropout)
@@ -633,26 +838,458 @@ class TransformerBatchNormEncoderLayer(nn.modules.Module):
         self.activation = F.gelu
 
     def forward(self, src: Tensor, src_mask: Optional[Tensor] = None,
-                src_key_padding_mask: Optional[Tensor] = None) -> Tensor:
+                src_key_padding_mask: Optional[Tensor] = None, plot_dir = None) -> Tensor:
         r"""Pass the input through the encoder layer.
 
         Args:
-            src: the sequence to the encoder layer (required). Shape: [seq_len, batch, embed_dim]
+            src: the sequence to the encoder layer (required). Shape: [batch, seq_len, embed_dim]
             src_mask: the mask for the src sequence (optional).
             src_key_padding_mask: the mask for the src keys per batch (optional).
 
         Shape:
             see the docs in Transformer class.
         """
-        src2, attn_output_weights = self.self_attn(src, src, src, attn_mask=src_mask,
-                              key_padding_mask=src_key_padding_mask, average_attn_weights=False)  # src2: [seq_len, batch_size, d_model], attn_output_weights: [batch, num_heads, seq_len, seq_len]
-        src = src + self.dropout1(src2)  # (seq_len, batch_size, d_model)
-        src = src.permute(1, 2, 0)  # (batch_size, d_model, seq_len)
+        if type(self.self_attn) == Attention_Rel_Scl:
+            # Attention_Rel_Scl allows plot_dir
+            src2, attn_output_weights = self.self_attn(src, src, src, attn_mask=src_mask,
+                                key_padding_mask=src_key_padding_mask, average_attn_weights=False, plot_dir=plot_dir)  # src2: [batch, seq_len, d_model], attn_output_weights: [batch, num_heads, seq_len, seq_len]
+        else:
+            src2, attn_output_weights = self.self_attn(src, src, src, attn_mask=src_mask,
+                                key_padding_mask=src_key_padding_mask, average_attn_weights=False)  # src2: [batch, seq_len, d_model], attn_output_weights: [batch, num_heads, seq_len, seq_len]
+
+        src = src + self.dropout1(src2)  # (batch, seq_len, d_model)  TODO temporarily removed
+        src = src.permute(0, 2, 1)  # (batch, d_model, seq_len)
         src = self.norm1(src)
-        src = src.permute(2, 0, 1)  # restore (seq_len, batch_size, d_model)
+        src = src.permute(0, 2, 1)  # restore (batch, seq_len, d_model)
         src2 = self.linear2(self.dropout(self.activation(self.linear1(src))))
-        src = src + self.dropout2(src2)  # (seq_len, batch_size, d_model)
-        src = src.permute(1, 2, 0)  # (batch_size, d_model, seq_len)
+        src = src + self.dropout2(src2)  # (batch, seq_len, d_model)
+        src = src.permute(0, 2, 1)  # (batch, d_model, seq_len)
         src = self.norm2(src)
-        src = src.permute(2, 0, 1)  # restore (seq_len, batch_size, d_model)
+        src = src.permute(0, 2, 1)  # restore (batch, seq_len, d_model)
         return src, attn_output_weights
+
+
+
+# ========================================================================================
+# Code from ConvTran: https://github.com/Navidfoumani/ConvTran/blob/main/Models/Attention.py
+# except that the relative bias table isn't stored here, we pass it as a mask instead.
+# Note that the attention bias is added after softmax, and we further use a gating param to weight them.
+# ========================================================================================
+class Attention_Rel_Scl(nn.Module):
+    def __init__(self, emb_size, num_heads, dropout, conv_projection, where_to_add_relpos, **kwargs):
+        super().__init__()
+        self.num_heads = num_heads
+        self.conv_projection = conv_projection
+        self.where_to_add_relpos = where_to_add_relpos
+        self.scale = emb_size ** -0.5
+        # self.to_qkv = nn.Linear(inp, inner_dim * 3, bias=False)
+
+        if conv_projection:
+            self.key = nn.Sequential(OrderedDict([
+                ('rearrange_to_conv', Rearrange('b t c -> b c t')),
+                ('conv', nn.Conv1d(emb_size, emb_size, kernel_size=5, padding=2,stride=1, bias=False, groups=emb_size)),
+                ('rearrange_from_conv', Rearrange('b c t -> b t c')),
+                ('relu', nn.ReLU()),
+                ('linear', nn.Linear(emb_size, emb_size, bias=False))
+            ]))
+            self.value = nn.Sequential(OrderedDict([
+                ('rearrange_to_conv', Rearrange('b t c -> b c t')),
+                ('conv', nn.Conv1d(emb_size, emb_size, kernel_size=5, padding=2,stride=1, bias=False, groups=emb_size)),
+                ('rearrange_from_conv', Rearrange('b c t -> b t c')),
+                ('relu', nn.ReLU()),
+                ('linear', nn.Linear(emb_size, emb_size, bias=False))
+            ]))
+            self.query = nn.Sequential(OrderedDict([
+                ('rearrange_to_conv', Rearrange('b t c -> b c t')),
+                ('conv', nn.Conv1d(emb_size, emb_size, kernel_size=5, padding=2,stride=1, bias=False, groups=emb_size)),
+                ('rearrange_from_conv', Rearrange('b c t -> b t c')),
+                ('relu', nn.ReLU()),
+                ('linear', nn.Linear(emb_size, emb_size, bias=False))
+            ]))
+        else:
+            self.key = nn.Linear(emb_size, emb_size, bias=False)
+            self.value = nn.Linear(emb_size, emb_size, bias=False)
+            self.query = nn.Linear(emb_size, emb_size, bias=False)
+            self.key.weight.data.copy_(torch.eye(emb_size))
+            self.value.weight.data.copy_(torch.eye(emb_size))
+            self.query.weight.data.copy_(torch.eye(emb_size))
+
+            # torch.nn.init.xavier_uniform_(self.key.weight)
+            # torch.nn.init.xavier_uniform_(self.value.weight)
+            # torch.nn.init.xavier_uniform_(self.query.weight)
+
+        self.dropout = nn.Dropout(dropout)
+        self.gating_param = nn.Parameter(torch.zeros(num_heads), requires_grad=True)  # nn.Parameter(torch.cat([-1*torch.ones(num_heads//2), torch.ones(num_heads//2)]))
+        # self.to_out = nn.LayerNorm(emb_size)
+
+    def forward(self, query, key, value, attn_mask, plot_dir=None, **kwargs):
+        """
+        Input (query/key/value) should be [batch, seq_len, embed_dim]. They can be identical
+        as the linear projections happen inside the method.
+        Mask should be [batch_size*num_heads, seq_len, seq_len]
+
+        Output is [batch, seq_len, embed_dim], and attn matrix [batch, num_heads, seq_len, seq_len]
+        """
+        batch_size, seq_len, _ = query.shape
+        # return torch.zeros_like(query), torch.eye((seq_len)).unsqueeze(0).unsqueeze(0).repeat((batch_size, self.num_heads, 1, 1))
+
+        k = self.key(key).reshape(batch_size, seq_len, self.num_heads, -1).permute(0, 2, 3, 1)
+        v = self.value(value).reshape(batch_size, seq_len, self.num_heads, -1).transpose(1, 2)
+        q = self.query(query).reshape(batch_size, seq_len, self.num_heads, -1).transpose(1, 2)
+        # # k shape = (batch_size, num_heads, d_head, seq_len)
+        # # v,q shape = (batch_size, num_heads, seq_len, d_head)
+        # print("Before linear projection")
+        # print(torch.dot(query[0, 0, :], key[0, 0, :]))
+        # print(torch.dot(query[0, 1, :], key[0, 1, :]))
+        # print(torch.dot(query[0, 2, :], key[0, 2, :]))
+        # print(torch.dot(query[0, 3, :], key[0, 3, :]))
+        # print("After lin proj")
+        # print(torch.dot(q[0, 0, 0, :], k[0, 0, :, 0]))
+        # print(torch.dot(q[0, 0, 0, :], k[0, 0, :, 1]))
+        # print(torch.dot(q[0, 0, 0, :], k[0, 0, :, 2]))
+        # print(torch.dot(q[0, 0, 0, :], k[0, 0, :, 3]))
+        # exit(1)
+        attn = torch.matmul(q, k) * self.scale  # attn shape (batch_size, num_heads, seq_len, seq_len)
+        #print(attn.shape)
+
+        # Add mask (relative position encoding) before softmax if specified
+        if self.where_to_add_relpos == 'before' and attn_mask is not None:
+            # Reshape attn_mask to (batch_size, num_heads, seq_len, seq_len)
+            attn_mask = rearrange(attn_mask, '(b h) l t -> b h l t', h=self.num_heads)
+            attn += attn_mask
+
+        # Perform softmax
+        attn = nn.functional.softmax(attn, dim=-1)
+        # print("Init attn", attn[0, 0, 0:10, 0:10])
+        if attn_mask is not None:
+            attn_mask = rearrange(attn_mask, '(b h) l t -> b h l t', h=self.num_heads)
+            # print("Attn mask", attn_mask[0, 0:8, 0:8])
+            content_attn = attn
+            if self.where_to_add_relpos == 'after':
+                attn = content_attn + attn_mask
+            elif self.where_to_add_relpos == "after_gating":
+                print("Gating (Pr position)", torch.sigmoid(self.gating_param))
+                gating = self.gating_param.view(1,-1,1,1)
+                attn = (1.-torch.sigmoid(gating))*content_attn + torch.sigmoid(gating)*F.softmax(attn_mask, dim=-1)  # First term is original content attention, second term is position attention
+                attn /= attn.sum(dim=-1).unsqueeze(-1)
+
+            if plot_dir is not None:
+                # PLOTTING ONLY
+                # Plot attention breakdown (content/position) for a single example, 'n_rows' heads
+                n_rows = 4
+                n_cols = 3
+                fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2*n_cols, 2*n_rows))
+
+                for r in range(n_rows):
+                    head_num = r * (attn.shape[1] // n_rows)
+                    max_value = 0.1 #/attn.shape[2]
+                    content_attn_head = content_attn[0, head_num, :, :]
+                    pos_attn_head = F.softmax(attn_mask, dim=-1)[0, head_num, :, :]
+                    total_attn_head = attn[0, head_num, :, :]
+                    axeslist[r, 0].imshow(content_attn_head.detach().cpu().numpy(), vmin=0, vmax=max_value)
+                    axeslist[r, 1].imshow(pos_attn_head.detach().cpu().numpy(), vmin=0, vmax=max_value)
+                    im = axeslist[r, 2].imshow(total_attn_head.detach().cpu().numpy(), vmin=0, vmax=max_value)
+                    if r == 0:
+                        axeslist[r, 0].set_title("Content attn")
+                        axeslist[r, 1].set_title("Position attn")
+                        axeslist[r, 2].set_title("Combined attn")
+                plt.tight_layout(rect=[0, 0.03, 0.95, 0.95])
+                plt.colorbar(im)
+                plt.suptitle("Attn breakdown, single example (each row is one head)")
+                plt.savefig(os.path.join(plot_dir, 'attention_breakdown.png'))
+                plt.close()
+
+        # print("Final attn", attn[0, 0, 0:10, 0:10])
+        out = torch.matmul(attn, v)
+        # out.shape = (batch_size, num_heads, seq_len, d_head)
+        out = out.transpose(1, 2)
+        # out.shape == (batch_size, seq_len, num_heads, d_head)
+        out = out.reshape(batch_size, seq_len, -1)
+        # out.shape == (batch_size, seq_len, d_model)
+        # out = self.to_out(out)
+        # print("Out", out[0, 0:10, :])
+        return out, attn
+
+
+
+# ========================================================================
+# Below code is from CvT: https://github.com/leoxiaobin/CvT/blob/main/lib/models/cls_cvt.py
+# ========================================================================
+from functools import partial
+from itertools import repeat
+# from torch._six import container_abcs
+
+import logging
+import os
+from collections import OrderedDict
+
+import numpy as np
+import scipy
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+from einops.layers.torch import Rearrange
+
+from timm.models.layers import DropPath, trunc_normal_
+
+
+class QuickGELU(nn.Module):
+    def forward(self, x: torch.Tensor):
+        return x * torch.sigmoid(1.702 * x)
+
+
+class Mlp(nn.Module):
+    def __init__(self,
+                 in_features,
+                 hidden_features=None,
+                 out_features=None,
+                 act_layer=nn.GELU,
+                 drop=0.):
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features)
+        self.act = act_layer()
+        self.fc2 = nn.Linear(hidden_features, out_features)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x
+
+
+class Attention(nn.Module):
+    def __init__(self,
+                 dim_in,
+                 dim_out,
+                 num_heads,
+                 qkv_bias=False,
+                 attn_drop=0.,
+                 proj_drop=0.,
+                 method='linear',  # 'dw_bn', TODO @joshuafan changed to make this similar to original to full transformer
+                 kernel_size=3,
+                 stride=1,
+                 padding="same"
+                 ):
+        super().__init__()
+        self.stride = stride
+        self.dim = dim_out
+        self.num_heads = num_heads
+        # head_dim = self.qkv_dim // num_heads
+        self.scale = dim_out ** -0.5
+
+        # Decide how much to use positional vs content attention
+        init_gating = torch.ones(self.num_heads)*2 # Second half of heads prefer position attention
+        init_gating[0:self.num_heads//2] = -2  # First half of heads prefer content attentio
+        self.gating_param = nn.Parameter(init_gating, requires_grad=True)
+
+        self.conv_proj_q = self._build_projection(
+            dim_in, dim_out, kernel_size, padding,
+            stride, 'linear' if method == 'avg' else method
+        )
+        self.conv_proj_k = self._build_projection(
+            dim_in, dim_out, kernel_size, padding,
+            stride, method
+        )
+        self.conv_proj_v = self._build_projection(
+            dim_in, dim_out, kernel_size, padding,
+            stride, method
+        )
+
+        self.proj_q = nn.Linear(dim_in, dim_out, bias=qkv_bias)
+        self.proj_k = nn.Linear(dim_in, dim_out, bias=qkv_bias)
+        self.proj_v = nn.Linear(dim_in, dim_out, bias=qkv_bias)
+
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim_out, dim_out)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def _build_projection(self,
+                          dim_in,
+                          dim_out,
+                          kernel_size,
+                          padding,
+                          stride,
+                          method):
+        if method == 'dw_bn':
+            proj = nn.Sequential(OrderedDict([
+                ('conv', nn.Conv1d(
+                    dim_in,
+                    dim_out,
+                    kernel_size=kernel_size,
+                    padding=padding,
+                    stride=stride,
+                    bias=False,
+                    groups=dim_in
+                )),
+                ('bn', nn.BatchNorm1d(dim_in)),
+                ('rearrage', Rearrange('b c t -> b t c')),
+            ]))
+        elif method == 'avg':
+            proj = nn.Sequential(OrderedDict([
+                ('avg', nn.AvgPool1d(
+                    kernel_size=kernel_size,
+                    padding=padding,
+                    stride=stride,
+                    ceil_mode=True
+                )),
+                ('rearrage', Rearrange('b c t -> b t c')),
+            ]))
+        elif method == 'linear':
+            proj = None
+        else:
+            raise ValueError('Unknown method ({})'.format(method))
+
+        return proj
+
+    def forward_conv(self, x):
+        """
+        Input/output are assumed to be [batch, seq_len, embed_dim] or [b, t, c]
+        """
+        x = rearrange(x, 'b t c -> b c t')
+
+        if self.conv_proj_q is not None:
+            q = self.conv_proj_q(x)
+        else:
+            q = rearrange(x, 'b c t -> b t c')
+
+        if self.conv_proj_k is not None:
+            k = self.conv_proj_k(x)
+        else:
+            k = rearrange(x, 'b c t -> b t c')
+
+        if self.conv_proj_v is not None:
+            v = self.conv_proj_v(x)
+        else:
+            v = rearrange(x, 'b c t -> b t c')
+
+        return q, k, v
+
+    def forward(self, x, src_mask=None):
+        """Input/output assumed to be [batch, seq_len, embed_dim]
+        mask should be [batch*num_heads, seq_len, seq_len]"""
+        if (
+            self.conv_proj_q is not None
+            or self.conv_proj_k is not None
+            or self.conv_proj_v is not None
+        ):
+            q, k, v = self.forward_conv(x)  # [batch, seq_len, embed_dim]
+        else:
+            q, k, v = x, x, x
+
+        q = rearrange(self.proj_q(q), 'b t (h d) -> b h t d', h=self.num_heads)
+        k = rearrange(self.proj_k(k), 'b t (h d) -> b h t d', h=self.num_heads)
+        v = rearrange(self.proj_v(v), 'b t (h d) -> b h t d', h=self.num_heads)
+
+        attn_score = torch.einsum('bhlk,bhtk->bhlt', [q, k]) * self.scale
+        # if src_mask is not None:
+        #     attn_score = attn_score + rearrange(src_mask, '(b h) l t -> b h l t', h=self.num_heads)
+
+        # Add mask (relative position encoding)
+        attn = F.softmax(attn_score, dim=-1)
+
+        if src_mask is not None:
+            print("Gating (Pr position)", torch.sigmoid(self.gating_param))
+            gating = self.gating_param.view(1,-1,1,1)
+            src_mask = rearrange(src_mask, '(b h) l t -> b h l t', h=self.num_heads)
+            attn = (1.-torch.sigmoid(gating))*attn + torch.sigmoid(gating)*F.softmax(src_mask, dim=-1)  # First term is original content attention, second term is position attention
+            attn /= attn.sum(dim=-1).unsqueeze(-1)
+        attn = self.attn_drop(attn)
+
+        x = torch.einsum('bhlt,bhtv->bhlv', [attn, v])
+        x = rearrange(x, 'b h t d -> b t (h d)')  # [batch, seq_len, embed_dim]
+
+        x = self.proj(x)
+        x = self.proj_drop(x)  # [batch, seq_len, embed_dim]
+        return x, attn
+
+
+class ConvTransformerBlock(nn.Module):
+    """
+    Should be exact replacement for TransformerEncoderBatchNormLayer.
+    """
+    def __init__(self,
+                 d_model,
+                 n_head,
+                 kernel_size,
+                 dim_feedforward=2048,
+                 dropout=0.1):
+        super().__init__()
+
+        self.norm1 = BatchNorm1d(d_model, eps=1e-5)
+        self.attn = Attention(
+            d_model, d_model, n_head, attn_drop=dropout, proj_drop=dropout,
+            kernel_size=kernel_size  # stride=stride, padding=padding,
+        )
+
+        self.drop_path = DropPath(dropout) \
+            if dropout > 0. else nn.Identity()
+        self.norm2 = BatchNorm1d(d_model, eps=1e-5)
+
+        self.mlp = Mlp(
+            in_features=d_model,
+            hidden_features=dim_feedforward,
+            drop=dropout
+        )
+
+    def forward(self, x, src_mask=None, src_key_padding_mask=None):
+        """
+        Input/output: [batch, seq_len (TIME), embed_dim] or [B, T, D]
+        """
+        res = x
+
+        # Change shapes just for BatchNorm1d, then back
+        x = x.permute((0, 2, 1))  # [batch, embed_dim, seq_len]
+        x = self.norm1(x)
+        x = x.permute((0, 2, 1))  # [batch, seq_len, embed_dim]
+
+        x, attn = self.attn(x, src_mask=src_mask)  # [batch, seq_len, embed_dim]
+        x = res + self.drop_path(x)
+
+        # Change shapes just for BatchNorm1d, then back
+        x = x.permute((0, 2, 1))  # [batch, embed_dim, seq_len]
+        x = self.norm2(x)
+        x = x.permute((0, 2, 1))  # [batch, seq_len, embed_dim]
+
+        x = x + self.drop_path(self.mlp(x))
+        return x, attn
+
+
+class ConvEmbed(nn.Module):
+    """ Image to Conv Embedding
+
+    """
+
+    def __init__(self,
+                 patch_size=7,
+                 in_chans=3,
+                 embed_dim=64,
+                 stride=4,
+                 padding=2,
+                 norm_layer=None):
+        super().__init__()
+        self.patch_size = patch_size
+
+        self.proj = nn.Conv1d(
+            in_chans, embed_dim,
+            kernel_size=patch_size,
+            stride=stride,
+            padding=padding
+        )
+        self.norm = norm_layer(embed_dim) if norm_layer else None
+
+    def forward(self, x):
+        """
+        Input [batch, in_chans, time] or [B, D, T]
+        Output [batch, embed_dim, time] or [B, D, T]
+        """
+        x = self.proj(x)
+
+        if self.norm:
+            x = self.norm(x)
+        return x

--- a/mvts_transformer/src/models/ts_climax.py
+++ b/mvts_transformer/src/models/ts_climax.py
@@ -356,7 +356,6 @@ class ClimaX(nn.Module):
             relative_coords = coords_t[:, None] - coords_t[None, :]  # [seq_len, seq_len]. Each entry (i, j) contains (i - j)
             relative_coords += seq_len - 1  # shift to start from 0
             self.register_buffer("relative_coords", relative_coords)
-
         elif relative_pos_encoding == "alibi":
             # FIXED bias for relative offsets. Each head has a different function.
             # Code from https://github.com/ofirpress/attention_with_linear_biases/issues/5

--- a/mvts_transformer/src/options.py
+++ b/mvts_transformer/src/options.py
@@ -187,7 +187,7 @@ class Options(object):
         self.parser.add_argument('--relative_pos_encoding', choices={'alibi', 'erpe', 'erpe_alibi_init', 'custom_rpe', 'erpe_symmetric', 'none'}, default='none',
                                  help='Method for RELATIVE positional encoding')
         self.parser.add_argument('--where_to_add_relpos', type=str, choices=["before", "after", "after_gating"], default="before",
-                                 help="""Where to add relative position offset (before or after softmax). If `after_gating` is set, do a learnable gating (convit style) where the mdoel can decide how much to weight position & content attention""")
+                                 help="""Where to add relative position offset (before or after softmax). If `after_gating` is set, do a learnable gating (convit style) where the model can decide how much to weight position & content attention""")
         self.parser.add_argument('--conv_projection', action='store_true',
                                  help="""If true, use conv instead of linear for Q/K/V""")
         self.parser.add_argument('--activation', choices={'relu', 'gelu'}, default='gelu',

--- a/mvts_transformer/src/options.py
+++ b/mvts_transformer/src/options.py
@@ -149,7 +149,7 @@ class Options(object):
                                  help='If set, plots a scatterplot of loss and loss with attention smoothness during supervised training')
 
         # Model
-        self.parser.add_argument('--model', choices={"swin", "transformer", "LINEAR", "swin_pool", "smooth", "patch", "climax_smooth", "climax", "convit", "convit_smooth", "convit_2", "ridge", "lasso"}, default="transformer",
+        self.parser.add_argument('--model', choices={"swin", "transformer", "LINEAR", "swin_pool", "smooth", "patch", "climax_smooth", "climax", "convit", "convit_smooth", "convit_2", "ridge", "lasso", "local_cnn"}, default="transformer",
                                  help="Model class")
         self.parser.add_argument('--smooth_attention', action='store_true',
                                  help="""If set, will smooth adjacent attention weights.""")
@@ -202,6 +202,12 @@ class Options(object):
                                  help='Number of time steps in each patch')
         self.parser.add_argument('--num_decoder_layers', type=int, default=2,
                                  help='Number of decoder layers')
+
+        # Local-CNN specific
+        self.parser.add_argument('--conv_type', type=str, choices=['hierarchical', 'local'], default='hierarchical',
+                                 help='Type of CNN')
+        self.parser.add_argument('--pool', type=str, choices=['seqpool', 'average', 'linear'], default='linear',
+                                 help='Type of final pooling')
 
         # C-Mixup specific
         self.parser.add_argument('--mixtype', type=str, default='random',

--- a/mvts_transformer/src/running.py
+++ b/mvts_transformer/src/running.py
@@ -581,6 +581,7 @@ class SupervisedRunner(BaseRunner):
                 else:
                     predictions = self.model(X.to(self.device), plot_dir=plot_dir)
 
+            predictions = predictions * config["label_std"] + config["label_mean"]
             all_predictions.append(predictions)
             all_targets.append(targets)
 
@@ -700,6 +701,7 @@ class SupervisedRunner(BaseRunner):
                 else:
                     predictions = self.model(X.to(self.device), plot_dir=plot_dir)
 
+            predictions = predictions * config["label_std"] + config["label_mean"]
             all_predictions.append(predictions.flatten().cpu().detach().numpy())
             all_targets.append(targets.flatten().cpu().detach().numpy())
 

--- a/mvts_transformer/src/running.py
+++ b/mvts_transformer/src/running.py
@@ -600,22 +600,6 @@ class SupervisedRunner(BaseRunner):
 
             if use_smoothing:  # attn_weights_layers: [batch, n_layers*n_heads, seq_len, seq_len]
 
-                # # Plot example attention matrices
-                # if epoch_num == config['epochs'] and i == 0:  # epoch_num is 1-based
-                #     n_rows = 5  # Examples to plot
-                #     n_matrices = attn_weights_layers.shape[1]  # Total number of attention maps per example (n_layers*n_heads)
-                #     n_cols = n_matrices//2
-                #     fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2*n_cols, 2*n_rows))
-
-                #     for r in range(n_rows):
-                #         for c in range(n_cols):
-                #             im = axeslist[r, c].imshow(attn_weights_layers[r, c*(n_matrices//n_cols), :, :].detach().cpu().numpy(), vmin=0, vmax=3/attn_weights_layers.shape[2])  #0/attn_weights_layers.shape[1])
-                #     plt.tight_layout(rect=[0, 0.03, 0.95, 0.95])
-                #     plt.colorbar(im)
-                #     plt.suptitle("Example attention matrices")
-                #     plt.savefig(os.path.join(config['plot_dir'], 'attention_matrices.png'))
-                #     plt.close()
-
                 attn_smoothness_loss = 0
                 attn_weights_layers = attn_weights_layers.reshape(-1, attn_weights_layers.shape[2], attn_weights_layers.shape[3])   # Convert to [something, seq_len, seq_len] - list of attention matrices
                 # attn_smoothness_loss = ((attn_weights_layers[:, :, 1:] - attn_weights_layers[:, :, :-1]) ** 2).sum(dim=2).mean()
@@ -626,9 +610,6 @@ class SupervisedRunner(BaseRunner):
 
             # Positional encoding smoothness loss. TODO - we should also save it so we can plot
             if (config["model"] == "climax_smooth") and (('learnable' in config['pos_encoding']) or (config['relative_pos_encoding'] == 'erpe')):
-                # if (epoch_num % 100 == 0 or epoch_num==1) and i == 0:
-                #     posenc_loss_batch = self.model.posenc_smoothness_loss(logger, plot_dir=os.path.join(config['plot_dir'], f"epoch{epoch_num}", epoch_num=epoch_num)
-                # else:
                 posenc_loss_batch = self.model.posenc_smoothness_loss(logger, plot_dir=plot_dir)
                 total_loss += config['lambda_posenc_smoothness'] * posenc_loss_batch
                 posenc_loss += posenc_loss_batch.cpu().detach().numpy()

--- a/mvts_transformer/src/running.py
+++ b/mvts_transformer/src/running.py
@@ -257,13 +257,14 @@ def validate(
         if keep_predictions:
             aggr_metrics, per_batch, predictions, targets = val_evaluator.evaluate(
                 epoch,
+                config,
                 keep_predictions=True,
                 require_padding=require_padding,
                 keep_all=True,
                 need_attn_weights=need_attn_weights
             )
         else:
-            aggr_metrics, per_batch = val_evaluator.evaluate(epoch, keep_all=True, require_padding=require_padding, need_attn_weights=need_attn_weights)
+            aggr_metrics, per_batch = val_evaluator.evaluate(epoch, config, keep_all=True, require_padding=require_padding, need_attn_weights=need_attn_weights)
 
     eval_runtime = time.time() - eval_start_time
     logger.info(
@@ -362,6 +363,7 @@ class BaseRunner(object):
     def evaluate(
         self,
         epoch_num=None,
+        config=None,
         keep_predictions=False,
         require_padding=False,
         keep_all=True,
@@ -462,6 +464,7 @@ class UnsupervisedRunner(BaseRunner):
     def evaluate(
         self,
         epoch_num=None,
+        config=None,
         keep_predictions=False,
         require_padding=False,
         keep_all=True,
@@ -557,19 +560,26 @@ class SupervisedRunner(BaseRunner):
             padding_masks = padding_masks.to(self.device)  # 0s: ignore
             # regression: (batch_size, num_labels); classification: (batch_size, num_classes) of logits
 
+            # Plot dir if needed
+            if i == 0 and epoch_num % 100 == 0:
+                plot_dir = os.path.join(config['plot_dir'], f'train_epoch{epoch_num}')
+                os.makedirs(plot_dir, exist_ok=True)
+            else:
+                plot_dir = None
+
             if config["mixtype"] != 'none':
                 X, targets = utils.generate_mixup_data(config, X, targets, self.device)
 
             if require_padding:
                 if need_attn_weights:
-                    predictions, attn_weights_layers = self.model(X.to(self.device), padding_masks)
+                    predictions, attn_weights_layers = self.model(X.to(self.device), padding_masks, plot_dir=plot_dir)
                 else:
-                    predictions = self.model(X.to(self.device), padding_masks)
+                    predictions = self.model(X.to(self.device), padding_masks, plot_dir=plot_dir)
             else:
                 if need_attn_weights:
-                    predictions, attn_weights_layers = self.model(X.to(self.device))
+                    predictions, attn_weights_layers = self.model(X.to(self.device), plot_dir=plot_dir)
                 else:
-                    predictions = self.model(X.to(self.device))
+                    predictions = self.model(X.to(self.device), plot_dir=plot_dir)
 
             all_predictions.append(predictions)
             all_targets.append(targets)
@@ -589,35 +599,36 @@ class SupervisedRunner(BaseRunner):
 
             if use_smoothing:  # attn_weights_layers: [batch, n_layers*n_heads, seq_len, seq_len]
 
-                # Plot example attention matrices
-                if epoch_num == config['epochs'] and i == 0:  # epoch_num is 1-based
-                    n_rows = 5  # Examples to plot
-                    n_cols = 4
-                    num_heads = attn_weights_layers.shape[1]  # Heads to plot
-                    fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2*n_cols, 2*n_rows))
+                # # Plot example attention matrices
+                # if epoch_num == config['epochs'] and i == 0:  # epoch_num is 1-based
+                #     n_rows = 5  # Examples to plot
+                #     n_matrices = attn_weights_layers.shape[1]  # Total number of attention maps per example (n_layers*n_heads)
+                #     n_cols = n_matrices//2
+                #     fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2*n_cols, 2*n_rows))
 
-                    for r in range(n_rows):
-                        for c in range(n_cols):
-                            im = axeslist[r, c].imshow(attn_weights_layers[r, c*(num_heads//n_cols), :, :].detach().cpu().numpy(), vmin=0, vmax=3/attn_weights_layers.shape[2])  #0/attn_weights_layers.shape[1])
-                    plt.tight_layout(rect=[0, 0.03, 0.95, 0.95])
-                    plt.colorbar(im)
-                    plt.suptitle("Example attention matrices")
-                    plt.savefig(os.path.join(config['plot_dir'], 'attention_matrices.png'))
-                    plt.close()
+                #     for r in range(n_rows):
+                #         for c in range(n_cols):
+                #             im = axeslist[r, c].imshow(attn_weights_layers[r, c*(n_matrices//n_cols), :, :].detach().cpu().numpy(), vmin=0, vmax=3/attn_weights_layers.shape[2])  #0/attn_weights_layers.shape[1])
+                #     plt.tight_layout(rect=[0, 0.03, 0.95, 0.95])
+                #     plt.colorbar(im)
+                #     plt.suptitle("Example attention matrices")
+                #     plt.savefig(os.path.join(config['plot_dir'], 'attention_matrices.png'))
+                #     plt.close()
 
                 attn_smoothness_loss = 0
                 attn_weights_layers = attn_weights_layers.reshape(-1, attn_weights_layers.shape[2], attn_weights_layers.shape[3])   # Convert to [something, seq_len, seq_len] - list of attention matrices
-                attn_smoothness_loss = ((attn_weights_layers[:, :, 1:] - attn_weights_layers[:, :, :-1]) ** 2).sum(dim=2).mean()
+                # attn_smoothness_loss = ((attn_weights_layers[:, :, 1:] - attn_weights_layers[:, :, :-1]) ** 2).sum(dim=2).mean()
+                attn_smoothness_loss = ((attn_weights_layers[:, :, 2:] + attn_weights_layers[:, :, :-2] - 2*attn_weights_layers[:, :, 1:-1]) ** 2).sum(dim=2).mean()
                 total_loss += smoothing_lambda * attn_smoothness_loss
 
             supervised_smoothing_loss += total_loss.cpu().detach().numpy()
 
             # Positional encoding smoothness loss. TODO - we should also save it so we can plot
             if (config["model"] == "climax_smooth") and (('learnable' in config['pos_encoding']) or (config['relative_pos_encoding'] == 'erpe')):
-                if (epoch_num==config["epochs"] or epoch_num==1) and i == 0:
-                    posenc_loss_batch = self.model.posenc_smoothness_loss(logger, plot_dir=config['plot_dir'], epoch_num=epoch_num)
-                else:
-                    posenc_loss_batch = self.model.posenc_smoothness_loss(logger, plot_dir=None)
+                # if (epoch_num % 100 == 0 or epoch_num==1) and i == 0:
+                #     posenc_loss_batch = self.model.posenc_smoothness_loss(logger, plot_dir=os.path.join(config['plot_dir'], f"epoch{epoch_num}", epoch_num=epoch_num)
+                # else:
+                posenc_loss_batch = self.model.posenc_smoothness_loss(logger, plot_dir=plot_dir)
                 total_loss += config['lambda_posenc_smoothness'] * posenc_loss_batch
                 posenc_loss += posenc_loss_batch.cpu().detach().numpy()
             else:
@@ -650,7 +661,7 @@ class SupervisedRunner(BaseRunner):
 
         return self.epoch_metrics
 
-    def evaluate(self, epoch_num=None, keep_predictions=False, require_padding=False, keep_all=True, plot=False, need_attn_weights=False):
+    def evaluate(self, epoch_num=None, config=None, keep_predictions=False, require_padding=False, keep_all=True, plot=False, need_attn_weights=False):
         self.model = self.model.eval()
 
         epoch_loss = 0  # total loss of epoch
@@ -671,16 +682,23 @@ class SupervisedRunner(BaseRunner):
             padding_masks = padding_masks.to(self.device)  # 0s: ignore
             # regression: (batch_size, num_labels); classification: (batch_size, num_classes) of logits
 
+            # Plot dir if needed
+            if i == 0 and epoch_num % 100 == 0 and config is not None:
+                plot_dir = os.path.join(config['plot_dir'], f'val_epoch{epoch_num}')
+                os.makedirs(plot_dir, exist_ok=True)
+            else:
+                plot_dir = None
+
             if require_padding:
                 if need_attn_weights:
-                    predictions, _ = self.model(X.to(self.device), padding_masks)
+                    predictions, _ = self.model(X.to(self.device), padding_masks, plot_dir=plot_dir)
                 else:
-                    predictions = self.model(X.to(self.device), padding_masks)
+                    predictions = self.model(X.to(self.device), padding_masks, plot_dir=plot_dir)
             else:
                 if need_attn_weights:
-                    predictions, _ = self.model(X.to(self.device))
+                    predictions, _ = self.model(X.to(self.device), plot_dir=plot_dir)
                 else:
-                    predictions = self.model(X.to(self.device))
+                    predictions = self.model(X.to(self.device), plot_dir=plot_dir)
 
             all_predictions.append(predictions.flatten().cpu().detach().numpy())
             all_targets.append(targets.flatten().cpu().detach().numpy())

--- a/mvts_transformer/src/utils/visualization_utils.py
+++ b/mvts_transformer/src/utils/visualization_utils.py
@@ -4,7 +4,7 @@ import os
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib import cm
-from matplotlib.colors import Normalize 
+from matplotlib.colors import Normalize
 from scipy.interpolate import interpn
 
 from sklearn.linear_model import LinearRegression
@@ -19,9 +19,9 @@ def plot_single_scatter_file(x, y, x_label, y_label, plot_dir, title_description
     if not os.path.exists(plot_dir):
         os.makedirs(plot_dir)
     title = title_description + "\n" + y_label + " vs " + x_label
-    plt.figure(figsize=(8, 8))   
+    plt.figure(figsize=(8, 8))
     plot_single_scatter(x, y, x_label, y_label, title, ax=plt.gca(), should_align=should_align)
-    plt.savefig(os.path.join(plot_dir, filename_description + y_label + "_vs_" + x_label + ".png"))  
+    plt.savefig(os.path.join(plot_dir, filename_description + y_label + "_vs_" + x_label + ".png"))
     plt.close()
 
 
@@ -52,6 +52,7 @@ def plot_single_scatter(x, y, x_label, y_label, title, ax=None, should_align=Tru
     slope = regression.coef_[0]
     intercept = regression.intercept_
     regression_line = slope * x + intercept
+    print(slope, intercept)
     regression_equation = 'y={:.2f}x+{:.2f}'.format(slope, intercept)
     identity_line = x
 
@@ -62,7 +63,7 @@ def plot_single_scatter(x, y, x_label, y_label, title, ax=None, should_align=Tru
     corr = np.corrcoef(x, y)[0, 1]
     mae = mean_absolute_error(x, y)
     mape = np.mean(100*np.abs((x - y) / (x + 1e-5)))
-    rmse =  math.sqrt(mean_squared_error(x, y)) 
+    rmse =  math.sqrt(mean_squared_error(x, y))
 
     # Plot scatterplot for this crop type
     if x.size > 500:
@@ -85,7 +86,7 @@ def plot_single_scatter(x, y, x_label, y_label, title, ax=None, should_align=Tru
 
 def density_scatter(x, y, ax=None, sort=True, bins=20, **kwargs):
     """Plot a scatter between x/y with density coloring (with 2d histogram).
-    
+
     Code from https://stackoverflow.com/questions/20105364/how-can-i-make-a-scatter-plot-colored-by-density-in-matplotlib
     """
 
@@ -106,3 +107,18 @@ def density_scatter(x, y, ax=None, sort=True, bins=20, **kwargs):
     norm = Normalize(vmin = np.min(z), vmax = np.max(z))
 
     return ax
+
+
+def plot_time_series(x, filename):
+    """ x should be shape [time, num_vars], numpy array
+    """
+    num_timesteps, num_vars = x.shape
+    fig, axeslist = plt.subplots(num_vars, 1, figsize=(10, 1.5*num_vars))
+    for var_idx in range(num_vars):
+        axeslist[var_idx].plot(np.arange(num_timesteps), x[:, var_idx])
+        axeslist[var_idx].set_xlabel('Timestep')
+        axeslist[var_idx].set_ylabel('Value')
+        axeslist[var_idx].set_title(f'Variable {var_idx}')
+    plt.tight_layout()
+    plt.savefig(filename)
+    plt.close()

--- a/mvts_transformer/src/utils/visualization_utils.py
+++ b/mvts_transformer/src/utils/visualization_utils.py
@@ -52,7 +52,6 @@ def plot_single_scatter(x, y, x_label, y_label, title, ax=None, should_align=Tru
     slope = regression.coef_[0]
     intercept = regression.intercept_
     regression_line = slope * x + intercept
-    print(slope, intercept)
     regression_equation = 'y={:.2f}x+{:.2f}'.format(slope, intercept)
     identity_line = x
 


### PR DESCRIPTION
- Added variants of relative position encodings, and allow them to be applied after or before softmax (or using Convit-style gating)
- Some other variant methods, including ConvTran and CvT. (ConvTran uses conv instead of linear to calculate query/key/value. CvT also allows conv projection *followed by linear*. I have not thoroughly tested everything with these methods.)
- Label normalization: the model now just needs to predict with mean 0, std 1. We rescale using the training mean/std of the label afterwards. 
- Added some plots of distances
- Baselines: linear regression and local CNN