### PR TITLE
Only compute timestep similarities when plotting; add multihead seqpool

### DIFF
--- a/mvts_transformer/src/main.py
+++ b/mvts_transformer/src/main.py
@@ -54,11 +54,11 @@ def main(config):
     logger.info("Running:\n{}\n".format(" ".join(sys.argv)))  # command used to run
 
     if config["seed"] is not None:
-        # os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Required due to CUBLAS https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Required due to CUBLAS https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility
         torch.manual_seed(config["seed"])
         torch.cuda.manual_seed(config["seed"])
         torch.cuda.manual_seed_all(config["seed"])
-        # torch.use_deterministic_algorithms(True)
+        torch.use_deterministic_algorithms(True)
         random.seed(config["seed"])
         np.random.seed(config["seed"])
 

--- a/mvts_transformer/src/main.py
+++ b/mvts_transformer/src/main.py
@@ -54,11 +54,11 @@ def main(config):
     logger.info("Running:\n{}\n".format(" ".join(sys.argv)))  # command used to run
 
     if config["seed"] is not None:
-        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Required due to CUBLAS https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility
+        # os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Required due to CUBLAS https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility
         torch.manual_seed(config["seed"])
         torch.cuda.manual_seed(config["seed"])
         torch.cuda.manual_seed_all(config["seed"])
-        torch.use_deterministic_algorithms(True)
+        # torch.use_deterministic_algorithms(True)
         random.seed(config["seed"])
         np.random.seed(config["seed"])
 

--- a/mvts_transformer/src/models/local_cnn.py
+++ b/mvts_transformer/src/models/local_cnn.py
@@ -1,6 +1,9 @@
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+from models.ClimaX.pos_embed import get_1d_sincos_pos_embed_from_grid
 
 
 def model_factory(config, data):
@@ -23,19 +26,21 @@ def model_factory(config, data):
             data.class_names) if task == "classification" else data.labels_df.shape[1]
         if config['model'] == 'local_cnn':
             return LocalCNN(in_channels=feat_dim, max_len=max_seq_len, num_classes=num_labels, final_emb_dim=config['d_model'],
-                            conv_type=config['conv_type'], pool=config['pool'])
+                            conv_type=config['conv_type'], pool=config['pool'], pos_encoding=config['pos_encoding'])
         else:
             raise ValueError("Unsupported model", config['model'])
     else:
         raise ValueError("Model class for task '{}' does not exist".format(task))
 
 class LocalCNN(nn.Module):
-    def __init__(self, in_channels, max_len=144, num_classes=1, final_emb_dim=512, conv_type="hierarchical", pool="seqpool"):
+    def __init__(self, in_channels, max_len=144, num_classes=1, final_emb_dim=512, conv_type="hierarchical", pool="seqpool", pos_encoding="none", n_heads=8):
         """
         conv_type can be hierarchical or local
 
-        pool can be seqpool (attention pooling in Compact Convolutional Transformer paper),
+        pool can be seqpool (attention pooling in Compact Convolutional Transformer paper), seqpool_multihead,
         average, or linear.
+
+        if posenc is True, add a positional encoding right before the pooling. NOT IMPLEMENTED YET
         """
         super().__init__()
         self.in_channels = in_channels
@@ -44,6 +49,7 @@ class LocalCNN(nn.Module):
         self.final_emb_dim = final_emb_dim
         self.conv_type = conv_type
         self.pool = pool
+        self.pos_encoding = pos_encoding
 
         if self.conv_type == "hierarchical":  # Gradually reduces number of timesteps
             self.conv = nn.Sequential(
@@ -75,9 +81,32 @@ class LocalCNN(nn.Module):
         else:
             raise ValueError("invalid conv_type")
 
+        # # Pos encoding for pooling
+        # self.pos_embed = None
+        # if pos_encoding == "learnable_sin_init":
+        #     self.pos_embed = nn.Parameter(torch.zeros(max_len, final_emb_dim), requires_grad=True)
+        #     pos_embed = get_1d_sincos_pos_embed_from_grid(
+        #         self.pos_embed.shape[-1],
+        #         np.arange(max_len)
+        #     )
+        #     self.pos_embed.data.copy_(torch.from_numpy(pos_embed).float())
+        #     final_emb_dim_with_posenc = 2 * final_emb_dim
+        # elif pos_encoding == "none":
+        #     final_emb_dim_with_posenc = final_emb_dim
+        # else:
+        #     raise NotImplementedError("Only learnable_sin_init or none positional encoding implemented so far")
+
         if self.pool == "seqpool":
             self.attention_pool = nn.Linear(final_emb_dim, 1)
             self.fc = nn.Linear(final_emb_dim, num_classes)
+        elif self.pool == "seqpool_multihead":
+            self.attention_pool = nn.Sequential(
+                nn.Linear(final_emb_dim, final_emb_dim),
+                nn.ReLU(),
+                nn.Linear(final_emb_dim, n_heads)
+            )
+            self.fc = nn.Linear(final_emb_dim*n_heads, num_classes)
+
         elif self.pool == "average":
             self.fc = nn.Sequential(
                 nn.AdaptiveAvgPool1d(1),
@@ -96,23 +125,35 @@ class LocalCNN(nn.Module):
         else:
             raise ValueError("invalid pool")
 
+
+
     def forward(self, x, plot_dir=None):
         """
         x should have shape [batch, time, channel]
         """
         x = x.permute((0, 2, 1))  # Convert to [batch, channel, time]
         x = self.conv(x)   # Convert to [batch, channel, time']  (may be fewer timesteps)
-        if self.pool == "seqpool":
+        if self.pool == "seqpool" or self.pool == "seqpool_multihead":
             x = x.permute((0, 2, 1))  # Convert back to [batch, time, channel]. For each example & timestep, use all channels to predict an attention score
+            # if self.pos_embed is not None:
+            #     x = x + self.pos_embed
 
-            # Code from https://github.com/SHI-Labs/Compact-Transformers/blob/main/src/utils/transformers.py#L208
-            # attention_pool outputs [batch, time, 1].
-            # Softmax normalizes it so that sum across the time dimension (for each example) is 1.
-            # Transpose it to [batch, 1, time], and then multiply with [batch, time, channel] -> [batch, 1, channel].
-            # Squeeze out the 1 to get [batch, channel].
-            # TODO add a positional encoding
-            x = torch.matmul(F.softmax(self.attention_pool(x), dim=1).transpose(-1, -2), x).squeeze(-2)
-            x = self.fc(x)
+            if self.pool == "seqpool":
+                # Code from https://github.com/SHI-Labs/Compact-Transformers/blob/main/src/utils/transformers.py#L208
+                # attention_pool outputs [batch, time, 1].
+                # Softmax normalizes it so that sum across the time dimension (for each example) is 1.
+                # Transpose it to [batch, 1, time], and then multiply with [batch, time, channel] -> [batch, 1, channel].
+                # Squeeze out the 1 to get [batch, channel].
+                # TODO add a positional encoding
+                x = torch.matmul(F.softmax(self.attention_pool(x), dim=1).transpose(-1, -2), x).squeeze(-2)
+                x = self.fc(x)
+            elif self.pool == "seqpool_multihead":
+                attn_weights = self.attention_pool(x)  # [batch, time, n_heads]
+                attn_weights = F.softmax(attn_weights, dim=1)  # [batch, time, n_heads]
+                attn_weights = attn_weights.permute((0, 2, 1))  # [batch, n_heads, time]
+                aggregated_x = torch.matmul(attn_weights, x)  # [batch, n_heads, channel]
+                aggregated_x = aggregated_x.reshape((aggregated_x.shape[0], -1))  # [batch, n_heads*channel]
+                x = self.fc(aggregated_x)
         elif self.pool in ["average", "linear"]:
             x = self.fc(x)
         else:

--- a/mvts_transformer/src/models/ts_climax.py
+++ b/mvts_transformer/src/models/ts_climax.py
@@ -723,8 +723,8 @@ class TransformerEncoder(nn.modules.Module):
             else:
               attn_weights_layers = torch.cat((attn_weights_layers, attn_weights), dim=1)  # attn_weights: [batch, n_layers*num_heads, seq_len, seq_len]
 
-            # DEBUGGING: Compute distances between timestep feature vectors
             if plot_dir is not None:
+                # FOR VISUALIZATIONS: Compute distances between timestep feature vectors
                 feat_detached = output.detach().cpu()
                 feature_distances_layers.append(torch.linalg.norm(feat_detached.unsqueeze(1) - feat_detached.unsqueeze(2), dim=3))
                 similarity_matrix_layers.append(F.cosine_similarity(feat_detached.unsqueeze(1), feat_detached.unsqueeze(2), dim=3))

--- a/mvts_transformer/src/models/ts_climax.py
+++ b/mvts_transformer/src/models/ts_climax.py
@@ -705,14 +705,16 @@ class TransformerEncoder(nn.modules.Module):
         # Via broadcasting, we convert this to [batch, seq_len, seq_len, embed_dim], then take the norm over embed_dim.
         # Result is [batch, seq_len, seq_len]
         feat_detached = output.detach().cpu()
-        feature_distances_layers = [torch.linalg.norm(feat_detached.unsqueeze(1) - feat_detached.unsqueeze(2), dim=3)]
 
-        # FOR VISUALIZATIONS: Compute cosine similarity between each timestep's feature vectors.
-        # "output" is assumed to be shape [batch, seq_len, embed_dim].
-        # Via broadcasting, we convert this to [batch, seq_len, seq_len, embed_dim], then compute similarity over embed_dim.
-        # Result is [batch, seq_len, seq_len]
-        # See https://pytorch.org/docs/stable/generated/torch.nn.functional.cosine_similarity.html
-        similarity_matrix_layers = [F.cosine_similarity(feat_detached.unsqueeze(1), feat_detached.unsqueeze(2), dim=3)]
+        if plot_dir is not None:
+            feature_distances_layers = [torch.linalg.norm(feat_detached.unsqueeze(1) - feat_detached.unsqueeze(2), dim=3)]
+
+            # FOR VISUALIZATIONS: Compute cosine similarity between each timestep's feature vectors.
+            # "output" is assumed to be shape [batch, seq_len, embed_dim].
+            # Via broadcasting, we convert this to [batch, seq_len, seq_len, embed_dim], then compute similarity over embed_dim.
+            # Result is [batch, seq_len, seq_len]
+            # See https://pytorch.org/docs/stable/generated/torch.nn.functional.cosine_similarity.html
+            similarity_matrix_layers = [F.cosine_similarity(feat_detached.unsqueeze(1), feat_detached.unsqueeze(2), dim=3)]
 
         # Compute forward pass
         for mod in self.layers:
@@ -723,9 +725,10 @@ class TransformerEncoder(nn.modules.Module):
               attn_weights_layers = torch.cat((attn_weights_layers, attn_weights), dim=1)  # attn_weights: [batch, n_layers*num_heads, seq_len, seq_len]
 
             # DEBUGGING: Compute distances between timestep feature vectors
-            feat_detached = output.detach().cpu()
-            feature_distances_layers.append(torch.linalg.norm(feat_detached.unsqueeze(1) - feat_detached.unsqueeze(2), dim=3))
-            similarity_matrix_layers.append(F.cosine_similarity(feat_detached.unsqueeze(1), feat_detached.unsqueeze(2), dim=3))
+            if plot_dir is not None:
+                feat_detached = output.detach().cpu()
+                feature_distances_layers.append(torch.linalg.norm(feat_detached.unsqueeze(1) - feat_detached.unsqueeze(2), dim=3))
+                similarity_matrix_layers.append(F.cosine_similarity(feat_detached.unsqueeze(1), feat_detached.unsqueeze(2), dim=3))
 
         # VISUALIZATIONS
         if plot_dir is not None:

--- a/mvts_transformer/src/models/ts_climax.py
+++ b/mvts_transformer/src/models/ts_climax.py
@@ -700,13 +700,12 @@ class TransformerEncoder(nn.modules.Module):
 
         attn_weights_layers = None
 
-        # FOR VISUALIZATIONS: Compute Euclidean distance between each timestep's feature vectors.
-        # "output" is assumed to be shape [batch, seq_len, embed_dim].
-        # Via broadcasting, we convert this to [batch, seq_len, seq_len, embed_dim], then take the norm over embed_dim.
-        # Result is [batch, seq_len, seq_len]
-        feat_detached = output.detach().cpu()
-
         if plot_dir is not None:
+            # FOR VISUALIZATIONS: Compute Euclidean distance between each timestep's feature vectors.
+            # "output" is assumed to be shape [batch, seq_len, embed_dim].
+            # Via broadcasting, we convert this to [batch, seq_len, seq_len, embed_dim], then take the norm over embed_dim.
+            # Result is [batch, seq_len, seq_len]
+            feat_detached = output.detach().cpu()
             feature_distances_layers = [torch.linalg.norm(feat_detached.unsqueeze(1) - feat_detached.unsqueeze(2), dim=3)]
 
             # FOR VISUALIZATIONS: Compute cosine similarity between each timestep's feature vectors.

--- a/mvts_transformer/src/options.py
+++ b/mvts_transformer/src/options.py
@@ -206,7 +206,7 @@ class Options(object):
         # Local-CNN specific
         self.parser.add_argument('--conv_type', type=str, choices=['hierarchical', 'local'], default='hierarchical',
                                  help='Type of CNN')
-        self.parser.add_argument('--pool', type=str, choices=['seqpool', 'average', 'linear'], default='linear',
+        self.parser.add_argument('--pool', type=str, choices=['seqpool', 'average', 'linear', 'seqpool_multihead'], default='linear',
                                  help='Type of final pooling')
 
         # C-Mixup specific

--- a/mvts_transformer/src/run_cnn.sh
+++ b/mvts_transformer/src/run_cnn.sh
@@ -1,0 +1,22 @@
+# Baseline
+DATA=${1}
+
+for LR in 1e-3 1e-2
+do
+    for POOL in seqpool
+    do
+        for CONV_TYPE in local
+        do
+            for SEED in 0 1 2
+            do
+                python main.py --comment "CNN_${DATA}" \
+                    --seed $SEED --name CNN_${DATA} \
+                    --records_file stats/CNN_${DATA}_${POOL}_${CONV}.xls \
+                    --data_dir /mnt/beegfs/bulk/mirror/jyf6/datasets/TSER/$DATA/ --data_class tsra \
+                    --pattern TRAIN --val_ratio 0.2 --epochs 500 --lr $LR \
+                    --optimizer RAdam --task regression --model local_cnn --pool $POOL --conv_type $CONV_TYPE \
+                    --plot_loss --plot_accuracy
+            done
+        done
+    done
+done

--- a/mvts_transformer/src/run_rpe.sh
+++ b/mvts_transformer/src/run_rpe.sh
@@ -1,20 +1,20 @@
-# Call ./run_rpe.sh AppliancesEnergy
+# Usage: ./run_rpe.sh AppliancesEnergy
 
 DATA=${1}
-for POSENC in erpe_alibi_init
+for POSENC in erpe
 do
     for LAM in 0
     do
         for SEED in 0
         do
             python main.py --comment "ClimaX ${DATA}" \
-                --seed $SEED --name ClimaX_smooth_${DATA}_ERPEALIBI_ATTNSMOOTH \
+                --seed $SEED --name ClimaX_smooth_${DATA}_ERPE \
                 --records_file ${DATA}_debug.xls \
                 --data_dir /mnt/beegfs/bulk/mirror/jyf6/datasets/TSER/$DATA/ --data_class tsra \
-                --pattern TRAIN --val_pattern TEST --epochs 1000 --lr 0.001 \
-                --num_layers 3 --num_heads 8 --d_model 128 --dim_feedforward 512 \
-                --optimizer RAdam  --pos_encoding learnable --relative_pos_encoding $POSENC --task regression \
-                --model climax_smooth --patch_length 1 --stride 1 --reg_lambda $LAM --smooth_attention \
+                --pattern TRAIN --val_ratio 0.2 --epochs 500 --lr 0.001 \
+                --num_layers 3 --num_heads 16 --d_model 128 --dim_feedforward 256 \
+                --optimizer RAdam --pos_encoding learnable --relative_pos_encoding $POSENC --where_to_add_relpos after \
+                --task regression --model climax_smooth --patch_length 1 --stride 1 --reg_lambda $LAM --smooth_attention \
                 --lambda_posenc_smoothness 0 --plot_loss --plot_accuracy
         done
     done

--- a/mvts_transformer/src/running.py
+++ b/mvts_transformer/src/running.py
@@ -547,6 +547,7 @@ class SupervisedRunner(BaseRunner):
             self.classification = False
 
     def train_epoch(self, config, epoch_num=None, keep_predictions=False, require_padding=False, use_smoothing=False, smoothing_lambda=0, need_attn_weights=False):
+        train_start = time.time()
         self.model = self.model.train()
 
         epoch_loss = 0  # total loss of epoch
@@ -637,6 +638,8 @@ class SupervisedRunner(BaseRunner):
         epoch_loss = epoch_loss / total_samples
         self.epoch_metrics["epoch"] = epoch_num
         self.epoch_metrics["loss"] = epoch_loss
+        print("TRAIN EPOCH TIME:", time.time()-train_start)
+
 
         if keep_predictions:
             return self.epoch_metrics, torch.cat(all_predictions, dim=0), torch.cat(all_targets, dim=0), supervised_loss, supervised_smoothing_loss, posenc_loss

--- a/mvts_transformer/src/running.py
+++ b/mvts_transformer/src/running.py
@@ -547,7 +547,6 @@ class SupervisedRunner(BaseRunner):
             self.classification = False
 
     def train_epoch(self, config, epoch_num=None, keep_predictions=False, require_padding=False, use_smoothing=False, smoothing_lambda=0, need_attn_weights=False):
-        train_start = time.time()
         self.model = self.model.train()
 
         epoch_loss = 0  # total loss of epoch
@@ -646,7 +645,6 @@ class SupervisedRunner(BaseRunner):
         return self.epoch_metrics
 
     def evaluate(self, epoch_num=None, config=None, keep_predictions=False, require_padding=False, keep_all=True, plot=False, need_attn_weights=False):
-        eval_start = time.time()
         self.model = self.model.eval()
 
         epoch_loss = 0  # total loss of epoch


### PR DESCRIPTION
- Previously the code was computing pairwise similarity/distance between timesteps **every epoch**, which is really slow (70x worse). Now I only do that every 100 epochs when we are plotting. TODO - could make this more configurable. Here's the rough cost of 1 train epoch on AppliancesEnergy:

* 0.12 sec: without plotting/computing distances (can get down to 0.1 sec with non-deterministic algorithms. I don't think that gain is worth losing reproducibility.)
* 7 sec: computing distances, but no plotting
* 22 sec: computing distances and plotting

Also added SeqPool with multiple heads for the CNN, this could be ported over to Transformer.