### PR TITLE
Modify top-k implementation: after softmax

### DIFF
--- a/mvts_transformer/src/models/ts_climax.py
+++ b/mvts_transformer/src/models/ts_climax.py
@@ -1718,7 +1718,9 @@ class Attention_Rel_Scl(nn.Module):
                 
                 # RBF kernel: s_i,j = exp(-dist_sq / (2 * sigma^2))
                 sigma_sq = (self.krause_sigma ** 2).view(1, -1, 1, 1)  # [1, H, 1, 1]
-                content_attn = torch.exp(-dist_sq / (2 * sigma_sq + 1e-8))  # [B, H, T, T]
+
+                # NOTE: Removed exp, as the exp will be added back in the softmax
+                content_attn = -dist_sq / (2 * sigma_sq + 1e-8)  # [B, H, T, T]
             else:
                 # Standard dot-product attention
                 content_attn = torch.einsum('bhlk,bhkt->bhlt', [q, k]) * self.scale  # [B, H, T, T]
@@ -1805,12 +1807,20 @@ class Attention_Rel_Scl(nn.Module):
             if plot_dir is not None:
                 if self.where_to_add_relpos == "after_gating":
                     print("Gating (Pr position)", torch.sigmoid(self.gating_param))
+                    # print("attn mask without softmax", attn_mask[0, 4, 25:35, 25:35])
+                    # print("attn mask without softmax", attn_mask[0, 8, 25:35, 25:35])
+                    # print("attn mask without softmax", attn_mask[0, 10, 25:35, 25:35])
+                    # print("attn mask without softmax", attn_mask[0, 12, 25:35, 25:35])
+                    # print("Nonzero before topk", torch.count_nonzero(attn_before_topk[0, 8, :, :], dim=-1))
+                    # print("Nonzero", torch.count_nonzero(attn[0, 8, :, :], dim=-1))
+                    # print("Content attn", content_attn[0, 8, 0:10, 0:10])
+                    # exit(1)
 
                 # PLOTTING ONLY
                 # Plot attention breakdown (content/position) for a single example, 'n_rows' heads
                 n_rows = 8
                 n_cols = 4 if self.attention_type == 'krause' else 3
-                fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2*n_cols, 2*n_rows), layout="constrained", squeeze=False)
+                fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2.5*n_cols, 2*n_rows), layout="constrained", squeeze=False)
 
                 for r in range(n_rows):
                     head_num = r * (attn.shape[1] // n_rows)
@@ -1820,6 +1830,7 @@ class Attention_Rel_Scl(nn.Module):
                         pos_attn_head = F.softmax(attn_mask[0, head_num, :, :], dim=-1)
                     else:
                         pos_attn_head = attn_mask[0, head_num, :, :]
+
                     total_attn_head = attn_before_topk[0, head_num, :, :]
                     axeslist[r, 0].imshow(content_attn_head.detach().cpu().numpy(), vmin=0, vmax=max_value)
                     axeslist[r, 1].imshow(pos_attn_head.detach().cpu().numpy(), vmin=0, vmax=max_value)
@@ -1841,7 +1852,8 @@ class Attention_Rel_Scl(nn.Module):
                             axeslist[r, 1].set_title("Position attn\n(unnormalized)")
                             axeslist[r, 2].set_title("Combined:\nsoftmax(Content) + Position")
                         if self.attention_type == 'krause':
-                            axeslist[r, 3].set_title(f"After Krause top-{self.krause_top_k}")
+                            axeslist[r, 3].set_title(f"After top-{self.krause_top_k}")
+
                 fig.colorbar(im, ax=axeslist[r])
                 fig.suptitle("Attn breakdown, single example (each row is one head)")
                 plt.savefig(os.path.join(plot_dir, 'attention_breakdown.png'))

--- a/mvts_transformer/src/models/ts_climax.py
+++ b/mvts_transformer/src/models/ts_climax.py
@@ -1761,34 +1761,12 @@ class Attention_Rel_Scl(nn.Module):
 
             # If certain entries were masked out in attn_mask, also mask them out in content_attn. This is necessary if where_to_add_relpos is after_gating.
             mask_neginf = torch.isneginf(attn_mask)
-            if self.attention_type == 'krause':
-                content_attn = torch.where(mask_neginf, torch.zeros_like(content_attn), content_attn)
-            else:
-                content_attn = torch.where(mask_neginf, torch.full_like(content_attn, float('-inf')), content_attn)
+            content_attn = torch.where(mask_neginf, torch.full_like(content_attn, float('-inf')), content_attn)
 
         # Perform normalization
-        if self.attention_type == 'krause':
-            # Krause attention with optional relative position bias and top-k sparsity
-            
-            # Add relative position bias before top-k selection
-            # Adding full attn_mask (including -inf) ensures masked positions are never selected by top-k
-            if attn_mask is not None and self.where_to_add_relpos == 'before':
-                content_attn = content_attn + attn_mask
-            
-            if self.krause_top_k > 0:
-                B, H, T, _ = content_attn.shape
-                k = min(self.krause_top_k, T)                
-
-                topk_values, topk_indices = torch.topk(content_attn, k, dim=-1)  # [B, H, T, k]
-                sparse_attn = torch.full_like(content_attn, float('-inf'))
-                sparse_attn.scatter_(-1, topk_indices, topk_values)
-                content_attn = sparse_attn
-            
-            attn = F.softmax(content_attn, dim=-1)
-        elif (self.where_to_add_relpos in ['before', 'only_relpos']) and attn_mask is not None:
+        if (self.where_to_add_relpos in ['before', 'only_relpos']) and attn_mask is not None:
             # Add mask (relative position encoding) before softmax if specified
             attn = F.softmax(content_attn + attn_mask, dim=-1)
-
         else:
             # Take softmax of content attention first (relative position encoding added later)
             attn = F.softmax(content_attn, dim=-1) # [B, H, T, T]
@@ -1811,6 +1789,24 @@ class Attention_Rel_Scl(nn.Module):
                 # print("COMBINED", attn.shape, attn[0, 0, 0:8, 0:8])
                 # exit(1)
 
+        # Krause attention hard-top-k. NOTE: We are doing this after softmax, so we set the
+        # non-topk values to 0 instead of -inf, and then renormalize so rows sum to 1. 
+        attn_before_topk = attn
+        if self.attention_type == 'krause' and self.krause_top_k > 0:
+            B, H, T, _ = attn.shape
+            k = min(self.krause_top_k, T)                
+
+            topk_values, topk_indices = torch.topk(attn, k, dim=-1)  # [B, H, T, k]
+            sparse_attn = torch.zeros_like(attn)
+            sparse_attn.scatter_(-1, topk_indices, topk_values)
+            attn = sparse_attn / sparse_attn.sum(dim=-1, keepdim=True) # Renormalize so that rows sum to 1 after zeroing out some entries
+
+        print("content_attn", content_attn[6, 2, 30:40, 30:40])
+        print("attn mask", attn_mask[6, 2, 30:40, 30:40])
+        print("attn before hardtopk", attn_before_topk[6, 2, 30:40, 30:40])
+        print("attn after hardtopk", attn[6, 2, 30:40, 30:40])
+
+        if attn_mask is not None:
             if plot_dir is not None:
                 if self.where_to_add_relpos == "after_gating":
                     print("Gating (Pr position)", torch.sigmoid(self.gating_param))
@@ -1818,7 +1814,7 @@ class Attention_Rel_Scl(nn.Module):
                 # PLOTTING ONLY
                 # Plot attention breakdown (content/position) for a single example, 'n_rows' heads
                 n_rows = 8
-                n_cols = 3
+                n_cols = 4 if self.attention_type == 'krause' else 3
                 fig, axeslist = plt.subplots(n_rows, n_cols, figsize=(2*n_cols, 2*n_rows), layout="constrained", squeeze=False)
 
                 for r in range(n_rows):
@@ -1829,10 +1825,12 @@ class Attention_Rel_Scl(nn.Module):
                         pos_attn_head = F.softmax(attn_mask[0, head_num, :, :], dim=-1)
                     else:
                         pos_attn_head = attn_mask[0, head_num, :, :]
-                    total_attn_head = attn[0, head_num, :, :]
+                    total_attn_head = attn_before_topk[0, head_num, :, :]
                     axeslist[r, 0].imshow(content_attn_head.detach().cpu().numpy(), vmin=0, vmax=max_value)
                     axeslist[r, 1].imshow(pos_attn_head.detach().cpu().numpy(), vmin=0, vmax=max_value)
                     im = axeslist[r, 2].imshow(total_attn_head.detach().cpu().numpy(), vmin=0, vmax=max_value)
+                    if self.attention_type == 'krause':
+                        im = axeslist[r, 3].imshow(attn[0, head_num, :, :].detach().cpu().numpy(), vmin=0, vmax=max_value)
                     if r == 0:
                         if self.where_to_add_relpos == "after_gating":
                             axeslist[r, 0].set_title("Content attn\n(post-softmax)")
@@ -1847,10 +1845,17 @@ class Attention_Rel_Scl(nn.Module):
                             axeslist[r, 0].set_title("Content attn\n(post-softmax)")
                             axeslist[r, 1].set_title("Position attn\n(unnormalized)")
                             axeslist[r, 2].set_title("Combined:\nsoftmax(Content) + Position")
+                        if self.attention_type == 'krause':
+                            axeslist[r, 3].set_title(f"After Krause top-{self.krause_top_k}")
                 fig.colorbar(im, ax=axeslist[r])
                 fig.suptitle("Attn breakdown, single example (each row is one head)")
                 plt.savefig(os.path.join(plot_dir, 'attention_breakdown.png'))
                 plt.close()
+
+        # Print attn
+                print("attn mask", attn_mask[6, 2, 30:40, 30:40])
+        print("content_attn", content_attn[6, 2, 30:40, 30:40])
+
 
         # AttnScale
         if self.attn_scale:

--- a/mvts_transformer/src/models/ts_climax.py
+++ b/mvts_transformer/src/models/ts_climax.py
@@ -1801,11 +1801,6 @@ class Attention_Rel_Scl(nn.Module):
             sparse_attn.scatter_(-1, topk_indices, topk_values)
             attn = sparse_attn / sparse_attn.sum(dim=-1, keepdim=True) # Renormalize so that rows sum to 1 after zeroing out some entries
 
-        print("content_attn", content_attn[6, 2, 30:40, 30:40])
-        print("attn mask", attn_mask[6, 2, 30:40, 30:40])
-        print("attn before hardtopk", attn_before_topk[6, 2, 30:40, 30:40])
-        print("attn after hardtopk", attn[6, 2, 30:40, 30:40])
-
         if attn_mask is not None:
             if plot_dir is not None:
                 if self.where_to_add_relpos == "after_gating":
@@ -1851,11 +1846,6 @@ class Attention_Rel_Scl(nn.Module):
                 fig.suptitle("Attn breakdown, single example (each row is one head)")
                 plt.savefig(os.path.join(plot_dir, 'attention_breakdown.png'))
                 plt.close()
-
-        # Print attn
-                print("attn mask", attn_mask[6, 2, 30:40, 30:40])
-        print("content_attn", content_attn[6, 2, 30:40, 30:40])
-
 
         # AttnScale
         if self.attn_scale:

--- a/mvts_transformer/src/options.py
+++ b/mvts_transformer/src/options.py
@@ -180,8 +180,6 @@ class Options(object):
                                  help="""Only applicable for ClimaX. If set to a non-negative integer, restrict attention to tokens within this distance""")
         self.parser.add_argument('--causal_mask', action='store_true',
                                  help="""Only applicable for ClimaX. If set, uses causal mask in self-attention.""")
-        self.parser.add_argument('--residual_weight', action='store_true',
-                                 help="""Only applicable for ClimaX. If set, allows the model to learn how much of the residual connection to use, by multiplying the residual by a learnable parameter.""")
         self.parser.add_argument('--reg_lambda', type=float, default=0,
                                  help="""Regularizing weight for loss from attention smoothing.""")
         self.parser.add_argument('--reg_lambda_pool', type=float, default=0,
@@ -200,7 +198,7 @@ class Options(object):
                                  help="""Initial value for learnable sigma in Krause attention RBF kernel.""")
         self.parser.add_argument('--krause_top_k', type=int, default=-1,
                                  help="""Top-k sparsity for Krause attention. -1 means no sparsity (use all tokens in window). Combine with --local_mask for bounded-confidence behavior.""")
-        
+
         # Oversmoothing tracking
         self.parser.add_argument('--track_oversmoothing', action='store_true',
                                  help="Track oversmoothing metrics (effective rank, cosine similarity, attention entropy, high-freq ratio)")
@@ -210,6 +208,8 @@ class Options(object):
                                  help="Compute oversmoothing metrics every N epochs (default: 1)")
         self.parser.add_argument('--pre_norm', action='store_true',
                                  help="""If set, normalize before attention.""")
+        self.parser.add_argument('--residual_weight', action='store_true',
+                                 help="""Only applicable for ClimaX. If set, allows the model to learn how much of the residual connection to use, by multiplying the residual by a learnable parameter.""")
         self.parser.add_argument('--qkv_identity_init', action='store_true',
                                  help="""If set, initialize W_Q, W_K, and W_V matrices to identity, so that at the beginning of training, attention is simply dot product similarity between input tokens. Only applicable if not using conv_projection.""")
         self.parser.add_argument('--tied_qk', action='store_true',

--- a/mvts_transformer/src/repro_scripts/exp_20260107/oversmoothing_baseline_krause.sh
+++ b/mvts_transformer/src/repro_scripts/exp_20260107/oversmoothing_baseline_krause.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# ============================= USAGE ==============================
+# Best attempt to reproduce Zerveas TST results.
+
+# ./repro_scripts/repro_tst/repro_tst.sh <DATASET>
+# (replace <DATASET> with one of: AppliancesEnergy BeijingPM10Quality BeijingPM25Quality BenzeneConcentration IEEEPPG LiveFuelMoistureContent)
+# Don't forget to change DATA_DIR and "ACTIVATE ENVIRONMENT" commands.
+
+# Results will be written to `output/${OUTPUT_FILE}.xls` (you can modify OUTPUT_FILE in this script).
+# NOTE: The "test loss" column is MSE, take square root to get RMSE
+
+# ======== SLURM BOILERPLATE - Ignore if not using Slurm. =========
+# Request the full partition
+#SBATCH -p full
+#SBATCH --exclude=c0020,c0002
+# Name the job so it's meaningful in the job list
+#SBATCH -J erpe_convalibi
+# Request 1 V100 GPU
+#SBATCH --gpus v100:1
+# Request 4 CPU cores (8 hyperthreads).
+#SBATCH -c 8
+# Specify the resources should be assigned to a single task on one node.
+#SBATCH -N 1 -n 1
+# Request a total of 80GB RAM
+#SBATCH --mem=80GB
+# Request a walltime limit of 72 hours
+#SBATCH -t 72:00:00
+
+# ============================ DATASET ============================
+DATA=$1
+echo $DATA
+DATA_DIR="/mnt/beegfs/bulk/mirror/jyf6/datasets/TSER/$DATA/"  # TODO: Change this!!!
+
+# ========== ACTIVATE ENVIRONMENT (TODO: Change this!!!) ==========
+source ~/.bashrc
+conda activate tser
+# ======================= HYPERPARAMETERS =========================
+# Default settings
+BS=128
+PATCH=1
+STRIDE=1
+PATIENCE=100
+
+# Dataset-specific overrides
+if [ "$DATA" = "AppliancesEnergy" ]; then
+    BS=16  # Use smaller batch size for AppliancesEnergy, since there are only 95 train examples
+    PATIENCE=500
+    SPLIT="--val_sequential_split"
+elif [ "$DATA" = "BenzeneConcentration" ]; then
+    PATIENCE=200
+    SPLIT="--val_sequential_split"
+elif [ "$DATA" = "IEEEPPG" ]; then
+    PATIENCE=200
+    PATCH=16
+    STRIDE=8
+    SPLIT="--val_sequential_split"
+elif [ "$DATA" = "LiveFuelMoistureContent" ]; then
+    PATCH=8
+    STRIDE=4
+    SPLIT="--val_sequential_split"
+fi
+
+
+# 1) Abspos
+# 2) Pool
+# 3) Relpos: after_gating, convalibi_init
+# 4) Attn smoothing
+# 5) L2 attn/learnable scale/prenorm
+
+OUTPUT_DIR="./output/oversmoothing_krause"
+OUTPUT_FILE="${DATA}_OVERSMOOTHING_KRAUSE"
+
+for LR in 1e-3 1e-2
+do
+    for CONVIT_SLOPE in 1
+    do
+        for NOISE in 0
+        do
+            for HEADS in 16
+            do
+                for SMOOTH in 1e-3
+                do
+                    for L1 in 0 
+                    do
+                        for SIGMA_INIT in 0.1 1 10
+                        do
+                            for TOPK in 8 16
+                            do
+                                for SEED in 0
+                                do
+                                    PARAM_STR="LR=${LR}_SLOPE=${CONVIT_SLOPE}_LAM=${LAM}_HEADS=${HEADS}"
+
+                                    # Baseline, convalibi init relpos, before softmax
+                                    python main.py --output_dir "$OUTPUT_DIR" \
+                                        --seed $SEED --name "${OUTPUT_FILE}_${PARAM_STR}"  \
+                                        --records_file "${OUTPUT_DIR}/${OUTPUT_FILE}.xls" \
+                                        --data_dir $DATA_DIR --data_class tsra \
+                                        --pattern TRAIN --val_ratio 0.2 $SPLIT \
+                                        --epochs 2000 --patience $PATIENCE \
+                                        --lr $LR --batch_size $BS --input_noise_std $NOISE \
+                                        --num_layers 3 --num_heads $HEADS --d_model 128 --dim_feedforward 256 \
+                                        --optimizer RAdam --task regression \
+                                        --plot_loss --plot_accuracy \
+                                        --model climax_smooth --patch_length $PATCH --stride $STRIDE --smooth_attention --normalize_label \
+                                        --pos_encoding learnable_sin_init --where_to_add_abspos start_concat \
+                                        --relative_pos_encoding erpe_convalibi_init --where_to_add_relpos before --convit_slope $CONVIT_SLOPE --alibi_min_slope 0.1 --alibi_max_slope 100 \
+                                        --pool seqpool_multihead --attention_type krause \
+                                        --krause_sigma_init $SIGMA_INIT --krause_top_k $TOPK \
+                                        --reg_lambda $SMOOTH --reg_lambda_pool $SMOOTH --l1_reg $L1
+                                    exit
+                                done
+                            done
+                        done
+                    done
+                done
+            done
+        done
+    done
+done
+
+python test_best.py --records_file "${OUTPUT_DIR}/${OUTPUT_FILE}.xls"
+
+# TODO: Pooling seqpool_cls
+# TODO: absolute positional encoding: concat start

--- a/mvts_transformer/src/repro_scripts/exp_20260107/oversmoothing_baseline_krause.sh
+++ b/mvts_transformer/src/repro_scripts/exp_20260107/oversmoothing_baseline_krause.sh
@@ -69,11 +69,11 @@ fi
 # 5) L2 attn/learnable scale/prenorm
 
 OUTPUT_DIR="./output/oversmoothing_krause"
-OUTPUT_FILE="${DATA}_OVERSMOOTHING_KRAUSE"
+OUTPUT_FILE="${DATA}_OVERSMOOTHING_KRAUSE_CONVIT10"
 
 for LR in 1e-3 1e-2
 do
-    for CONVIT_SLOPE in 1
+    for CONVIT_SLOPE in 10
     do
         for NOISE in 0
         do
@@ -104,11 +104,10 @@ do
                                         --plot_loss --plot_accuracy \
                                         --model climax_smooth --patch_length $PATCH --stride $STRIDE --smooth_attention --normalize_label \
                                         --pos_encoding learnable_sin_init --where_to_add_abspos start_concat \
-                                        --relative_pos_encoding erpe_convalibi_init --where_to_add_relpos before --convit_slope $CONVIT_SLOPE --alibi_min_slope 0.1 --alibi_max_slope 100 \
+                                        --relative_pos_encoding erpe_convalibi_init --where_to_add_relpos after_gating --convit_slope $CONVIT_SLOPE --alibi_min_slope 0.1 --alibi_max_slope 100 \
                                         --pool seqpool_multihead --attention_type krause \
                                         --krause_sigma_init $SIGMA_INIT --krause_top_k $TOPK \
                                         --reg_lambda $SMOOTH --reg_lambda_pool $SMOOTH --l1_reg $L1
-                                    exit
                                 done
                             done
                         done

--- a/mvts_transformer/src/repro_scripts/exp_20260107/oversmoothing_baseline_krause.sh
+++ b/mvts_transformer/src/repro_scripts/exp_20260107/oversmoothing_baseline_krause.sh
@@ -19,11 +19,11 @@
 # Request 1 V100 GPU
 #SBATCH --gpus v100:1
 # Request 4 CPU cores (8 hyperthreads).
-#SBATCH -c 8
+#SBATCH -c 4
 # Specify the resources should be assigned to a single task on one node.
 #SBATCH -N 1 -n 1
-# Request a total of 80GB RAM
-#SBATCH --mem=80GB
+# Request a total of 120GB RAM
+#SBATCH --mem=120GB
 # Request a walltime limit of 72 hours
 #SBATCH -t 72:00:00
 
@@ -35,6 +35,7 @@ DATA_DIR="/mnt/beegfs/bulk/mirror/jyf6/datasets/TSER/$DATA/"  # TODO: Change thi
 # ========== ACTIVATE ENVIRONMENT (TODO: Change this!!!) ==========
 source ~/.bashrc
 conda activate tser
+
 # ======================= HYPERPARAMETERS =========================
 # Default settings
 BS=128
@@ -68,24 +69,24 @@ fi
 # 4) Attn smoothing
 # 5) L2 attn/learnable scale/prenorm
 
-OUTPUT_DIR="./output/oversmoothing_krause"
-OUTPUT_FILE="${DATA}_OVERSMOOTHING_KRAUSE_CONVIT10"
+OUTPUT_DIR="./output/krause_qkvidentity_2LAYER_20260407"
+OUTPUT_FILE="${DATA}_KRAUSE_QKVIDENTITY_2LAYER_20260407"
 
 for LR in 1e-3 1e-2
 do
-    for CONVIT_SLOPE in 10
+    for CONVIT_SLOPE in 1
     do
         for NOISE in 0
         do
             for HEADS in 16
             do
-                for SMOOTH in 1e-3
+                for SMOOTH in 0 1e-4 1e-2
                 do
-                    for L1 in 0 
+                    for L1 in 0
                     do
-                        for SIGMA_INIT in 0.1 1 10
+                        for SIGMA_INIT in 3
                         do
-                            for TOPK in 8 16
+                            for TOPK in 4 16
                             do
                                 for SEED in 0
                                 do
@@ -99,15 +100,16 @@ do
                                         --pattern TRAIN --val_ratio 0.2 $SPLIT \
                                         --epochs 2000 --patience $PATIENCE \
                                         --lr $LR --batch_size $BS --input_noise_std $NOISE \
-                                        --num_layers 3 --num_heads $HEADS --d_model 128 --dim_feedforward 256 \
+                                        --num_layers 2 --num_heads $HEADS --d_model 128 --dim_feedforward 256 \
                                         --optimizer RAdam --task regression \
                                         --plot_loss --plot_accuracy \
                                         --model climax_smooth --patch_length $PATCH --stride $STRIDE --smooth_attention --normalize_label \
                                         --pos_encoding learnable_sin_init --where_to_add_abspos start_concat \
-                                        --relative_pos_encoding erpe_convalibi_init --where_to_add_relpos after_gating --convit_slope $CONVIT_SLOPE --alibi_min_slope 0.1 --alibi_max_slope 100 \
+                                        --relative_pos_encoding erpe_convalibi_init --where_to_add_relpos after_gating \
+                                        --convit_slope $CONVIT_SLOPE --alibi_min_slope 0.1 --alibi_max_slope 10 \
                                         --pool seqpool_multihead --attention_type krause \
                                         --krause_sigma_init $SIGMA_INIT --krause_top_k $TOPK \
-                                        --reg_lambda $SMOOTH --reg_lambda_pool $SMOOTH --l1_reg $L1
+                                        --reg_lambda $SMOOTH --reg_lambda_pool $SMOOTH --l1_reg $L1 --qkv_identity_init --num_workers 4
                                 done
                             done
                         done

--- a/mvts_transformer/src/repro_scripts/ladaa_tuning.sh
+++ b/mvts_transformer/src/repro_scripts/ladaa_tuning.sh
@@ -20,11 +20,11 @@
 # Request 1 V100 GPU
 #SBATCH --gpus v100:1
 # Request 4 CPU cores (8 hyperthreads).
-#SBATCH -c 8
+#SBATCH -c 4
 # Specify the resources should be assigned to a single task on one node.
 #SBATCH -N 1 -n 1
 # Request a total of 80GB RAM
-#SBATCH --mem=20GB
+#SBATCH --mem=100GB
 # Request a walltime limit of 72 hours
 #SBATCH -t 72:00:00
 
@@ -63,38 +63,41 @@ fi
 
 
 # OUTPUT FILE
-OUTPUT_DIR="./output/LADAA3_20260223"
-OUTPUT_FILE="LADAA3_20260223_${DATA}"
+OUTPUT_DIR="./output/LADAA4_20260407_STARTCONCAT"
+OUTPUT_FILE="LADAA4_20260407_STARTCONCAT_LAYERS_${DATA}"
 
 # TUNING
 for LR in 1e-3 1e-2
 do
-    for CONVIT_SLOPE in 0.1 1 10
+    for CONVIT_SLOPE in 1
     do
-        for HEADS in 16
+        for LAYERS in 1 2
         do
-            for SMOOTH in 0 1e-3 
+            for HEADS in 16
             do
-                for L1 in 0 1e-3
+                for SMOOTH in 0 
                 do
-                    for SEED in 0
+                    for L1 in 0
                     do
-                        # BASIC
-                        PARAM_STR="LR=${LR}_POOLSMOOTH=${SMOOTH}_L1=${L1}_SLOPE=${CONVIT_SLOPE}_HEADS=${HEADS}_SEED=${SEED}"
-                        python main.py --output_dir "$OUTPUT_DIR" \
-                            --seed $SEED --name "${OUTPUT_FILE}_${PARAM_STR}"  \
-                            --records_file "${OUTPUT_DIR}/${OUTPUT_FILE}.xls" \
-                            --data_dir $DATA_DIR --data_class tsra \
-                            --pattern TRAIN --val_ratio 0.2 $SPLIT \
-                            --epochs 2000 --patience $PATIENCE \
-                            --lr $LR --batch_size $BS \
-                            --num_layers 3 --num_heads $HEADS --d_model 128 --dim_feedforward 256 \
-                            --optimizer RAdam --task regression \
-                            --plot_loss --plot_accuracy \
-                            --model climax_smooth --patch_length $PATCH --stride $STRIDE --smooth_attention --normalize_label \
-                            --pos_encoding learnable_sin_init --where_to_add_abspos before_pool_concat \
-                            --relative_pos_encoding erpe_convalibi_init --where_to_add_relpos only_relpos --convit_slope $CONVIT_SLOPE --alibi_min_slope 0.1 --alibi_max_slope 100 \
-                            --pool seqpool_multihead --reg_lambda_pool $SMOOTH --reg_lambda $SMOOTH --l1_reg $L1
+                        for SEED in 0
+                        do
+                            # BASIC
+                            PARAM_STR="LR=${LR}_POOLSMOOTH=${SMOOTH}_L1=${L1}_SLOPE=${CONVIT_SLOPE}_HEADS=${HEADS}_SEED=${SEED}"
+                            python main.py --output_dir "$OUTPUT_DIR" \
+                                --seed $SEED --name "${OUTPUT_FILE}_${PARAM_STR}"  \
+                                --records_file "${OUTPUT_DIR}/${OUTPUT_FILE}.xls" \
+                                --data_dir $DATA_DIR --data_class tsra \
+                                --pattern TRAIN --val_ratio 0.2 $SPLIT \
+                                --epochs 2000 --patience $PATIENCE \
+                                --lr $LR --batch_size $BS \
+                                --num_layers $LAYERS --num_heads $HEADS --d_model 128 --dim_feedforward 256 \
+                                --optimizer RAdam --task regression \
+                                --plot_loss --plot_accuracy \
+                                --model climax_smooth --patch_length $PATCH --stride $STRIDE --smooth_attention --normalize_label \
+                                --pos_encoding learnable_sin_init --where_to_add_abspos start_concat \
+                                --relative_pos_encoding erpe_convalibi_init --where_to_add_relpos only_relpos --convit_slope $CONVIT_SLOPE --alibi_min_slope 0.1 --alibi_max_slope 10 \
+                                --pool seqpool_multihead --reg_lambda_pool $SMOOTH --reg_lambda $SMOOTH --l1_reg $L1 --num_workers 4
+                        done
                     done
                 done
             done

--- a/mvts_transformer/src/repro_scripts/repro_tst/local_mask.sh
+++ b/mvts_transformer/src/repro_scripts/repro_tst/local_mask.sh
@@ -67,13 +67,13 @@ else
     continue
 fi
 
-OUTPUT_DIR="./output/debug_oversmoothing_metrics"
+OUTPUT_DIR="./output/local_mask_test"
 POOL="linear"
-for MASK in 0 
+for MASK in -1 0 4 8
 do
     OUTPUT_FILE="${DATA}_BS=${BS}_LOCALMASK=${MASK}_POOL=${POOL}"
 
-    for SEED in 1
+    for SEED in 0 1 2
     do
         PARAM_STR="SEED=${SEED}"
         python main.py --output_dir "$OUTPUT_DIR" \

--- a/mvts_transformer/src/repro_scripts/repro_tst/repro_tst.sh
+++ b/mvts_transformer/src/repro_scripts/repro_tst/repro_tst.sh
@@ -19,7 +19,7 @@
 # Request 1 V100 GPU
 #SBATCH --gpus v100:1
 # Request 4 CPU cores (8 hyperthreads).
-#SBATCH -c 8
+#SBATCH -c 4
 # Specify the resources should be assigned to a single task on one node.
 #SBATCH -N 1 -n 1
 # Request a total of 80GB RAM
@@ -97,7 +97,7 @@ fi
 # done
 
 OUTPUT_DIR="./output/repro_zerveas_20260406_CLIMAX_NOATTNDROPOUT"
-OUTPUT_FILE="${DATA}_repro_zerveas_20260406_CLIMAX_NOATTNDROPOUT_v2"
+OUTPUT_FILE="${DATA}_repro_zerveas_20260406_CLIMAX_NOATTNDROPOUT"
 
 for SEED in 0 1 2
 do


### PR DESCRIPTION
Change Krause top-k implementation to be after softmax (zeroing non-top-k entries out, then renormalizing). This way, it can be compatible with different ways of integrating relative positional encoding (before, after, after_gating, etc). Let me know if you catch any bugs, I still need to double-check